### PR TITLE
Simplify the pipeline and credentials

### DIFF
--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -1,9 +1,3 @@
-pipeline-tasks-git-url: https://github.com/18F/cg-pipeline-tasks.git
-pipeline-tasks-git-branch: master
-cg-deploy-bosh-git-url: https://github.com/18F/cg-deploy-bosh.git
-cg-deploy-bosh-git-branch: master
-bosh-io-cpi-repository: cloudfoundry-incubator/bosh-aws-cpi-release
-bosh-stemcell: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
 production-bucket-name: SECURE_BUCKET_PRODUCTION
 production-bucket-access-key-id: AWS_ACCESS_KEY_ID
 production-bucket-secret-access-key: AWS_SECRET_ACCESS_KEY

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -123,19 +123,10 @@ jobs:
   - aggregate:
     - get: pipeline-tasks
     - get: bosh-config
-      trigger: true
-      passed: [deploy-production-bosh]
     - get: bosh-release
-      trigger: true
-      passed: [deploy-production-bosh]
     - get: uaa-release
-      trigger: true
-      passed: [deploy-production-bosh]
     - get: cpi-release
-      trigger: true
-      passed: [deploy-production-bosh]
     - get: bosh-stemcell
-      passed: [deploy-production-bosh]
     - get: common-tooling
       trigger: true
   - task: bosh-manifest
@@ -285,28 +276,28 @@ resources:
 - name: cpi-release
   type: bosh-io-release
   source:
-    repository: {{bosh-io-cpi-repository}}
+    repository: cloudfoundry-incubator/bosh-aws-cpi-release
 
 - name: bosh-config
   type: git
   source:
-    uri: {{cg-deploy-bosh-git-url}}
-    branch: {{cg-deploy-bosh-git-branch}}
+    uri: https://github.com/18F/cg-deploy-bosh.git
+    branch: master
     paths:
     - bosh-deployment.yml
 
 - name: bosh-init-config
   type: git
   source:
-    uri: {{cg-deploy-bosh-git-url}}
-    branch: {{cg-deploy-bosh-git-branch}}
+    uri: https://github.com/18F/cg-deploy-bosh.git
+    branch: master
     paths:
     - bosh-init-deployment.yml
 
 - name: bosh-stemcell
   type: bosh-io-stemcell
   source:
-    name: {{bosh-stemcell}}
+    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
 
 - name: toolingbosh-deployment
   type: 18f-bosh-deployment
@@ -343,8 +334,8 @@ resources:
 - name: pipeline-tasks
   type: git
   source:
-    uri: {{pipeline-tasks-git-url}}
-    branch: {{pipeline-tasks-git-branch}}
+    uri: https://github.com/18F/cg-pipeline-tasks.git
+    branch: master
 
 - name: slack
   type: slack-notification


### PR DESCRIPTION
 - Don't make tooling dependent on staging
 - Go ahead and reference git repos directly
 - Reference AWS bits directly for CPI and stemcell

Fixes 18F/cg-atlas#31