### PR TITLE
Configure health monitor riemann plugin.

### DIFF
--- a/bosh-deployment.yml
+++ b/bosh-deployment.yml
@@ -22,6 +22,9 @@ meta:
     agent-password: ~
     registry-password: ~
     hm-password: ~
+  riemann:
+    host: ~
+    port: (( merge || "5555" ))
 
 name: (( meta.name ))
 
@@ -164,6 +167,10 @@ properties:
     resurrector_enabled: true
     resurrector:
       minimum_down_jobs: 3
+    riemann_enabled: true
+    riemann:
+      host: (( meta.riemann.host ))
+      port: (( meta.riemann.port ))
 
   aws: &aws
     access_key_id: (( meta.aws.access_key_id ))

--- a/secrets.example.yml
+++ b/secrets.example.yml
@@ -29,6 +29,9 @@ meta:
     agent-password: AGENT_PASSWORD
     registry-password: REGISTRY_PASSWORD
     hm-password: HM_PASSWORD
+  riemann:
+    host: 0.monitoring.monitoring.monitoring-prod.bosh
+    port: 5555
 
 networks:
   - name: default

--- a/secrets.example.yml
+++ b/secrets.example.yml
@@ -30,7 +30,7 @@ meta:
     registry-password: REGISTRY_PASSWORD
     hm-password: HM_PASSWORD
   riemann:
-    host: 0.monitoring.monitoring.monitoring-prod.bosh
+    host: 0.monitoring.monitoring.monitoring-production.bosh
     port: 5555
 
 networks:


### PR DESCRIPTION
This won't have any effect until https://github.com/cloudfoundry/bosh/pull/1337 is merged and we update bosh. After that, this patch should forward health monitor alerts and heartbeats to riemann.

Part of https://github.com/18F/cg-product/issues/17.

Question for @sharms and @LinuxBozo: when we set up the secrets, I assume we'll have staging bosh send riemann alerts to 0.monitoring.monitoring.monitoring-staging.bosh and production bosh send to 0.monitoring.monitoring.monitoring-prod.bosh. But what about tooling bosh? Our [VPC diagram](https://docs.google.com/drawings/d/1X1GZ664sjG5_JQ0Wpco430X_lK2Ozv-tgl5Wel9Je_g/edit?ts=5750a7f4) has a riemann instance in tooling, but I don't see that in govcloud. Should we add a riemann instance in the tooling vpc so tooling bosh has somewhere to send alerts?