### PR TITLE
[WIP] Emit uptime metrics for all non-whitelisted VMs

### DIFF
--- a/cronjobs/unknown-vms.sh
+++ b/cronjobs/unknown-vms.sh
@@ -12,33 +12,52 @@ PSQL=/var/vcap/packages/postgres/bin/psql
 AWSCLI=/var/vcap/packages/awslogs/bin/aws
 export LD_LIBRARY_PATH=/var/vcap/packages/awslogs/lib
 
+#function to build JMESpath query to exclude certain hosts based on ip
+query_filter() {
+    local IFS
+    unset IFS
+    local QUERY=""
+
+    for ip in ${1}; do
+        if [ -z "$QUERY" ]; then
+            QUERY="?PrivateIpAddress != "
+        else
+            QUERY="${QUERY} && PrivateIpAddress != "
+        fi
+        QUERY="${QUERY}\`$ip\`"
+    done
+
+    QUERY="Reservations[].Instances[${QUERY}] | "
+
+    echo ${QUERY}
+}
+
 # get a list of all the instances bosh has created
 KNOWN_INSTANCES=$($PSQL -h ${PGHOST} -U ${PGUSERNAME} -d ${PGDBNAME} -t -c "select uuid from instances")
-
-# build a JMESPath query to exclude hosts on our whitelist
-WHITELIST_QUERY=""
-for ip in ${INSTANCE_WHITELIST}; do
-	if [ -z "$WHITELIST_QUERY" ]; then
-		WHITELIST_QUERY="?PrivateIpAddress != "
-	else
-		WHITELIST_QUERY="${WHITELIST_QUERY} && PrivateIpAddress != "
-	fi
-	WHITELIST_QUERY="${WHITELIST_QUERY}\`$ip\`"
-done
-WHITELIST_QUERY="Reservations[].Instances[${WHITELIST_QUERY}] | "
 
 # find the VPC ID we want to enumerate
 VPCID=$(${AWSCLI} ec2 describe-vpcs --filter Name=tag:Name,Values=${VPC_NAME} --output text --query 'Vpcs[].VpcId')
 
 # find all instances in that VPC and emit a metric for each unknown host
-for id in $(${AWSCLI} ec2 describe-instances --max-items 500 --output text  --filter Name=vpc-id,Values=${VPCID} --query "${WHITELIST_QUERY} [].{\"aws_id\": InstanceId, \"bosh_id\": Tags[?Key==\`id\`].Value | [0]} | [].[bosh_id || aws_id]"); do
-	STATE="ok"
+for id in $(${AWSCLI} ec2 describe-instances --max-items 500 --output text  --filter Name=vpc-id,Values=${VPCID} --query "$(query_filter "${BOSH_DIRECTOR} ${INSTANCE_WHITELIST}") [].{\"aws_id\": InstanceId, \"bosh_id\": Tags[?Key==\`id\`].Value | [0]} | [].[bosh_id || aws_id]"); do
+    STATE="ok"
 
-	if [[ $KNOWN_INSTANCES != *${id}* ]]; then
-		STATE="critical"
-	fi
+    if [[ $KNOWN_INSTANCES != *${id}* ]]; then
+        STATE="critical"
+    fi
 
     ${RIEMANNC} --service "unknown-vm.found" --host ${id} --state ${STATE} --ttl 120 --metric_sint64 1
+done
+
+# emit metrics with bosh id, iaas id, and uptime info for all non-whitelisted VMs
+IFS=$'\n'
+for vminfo in $(${AWSCLI} ec2 describe-instances --max-items 500 --output text  --filter Name=vpc-id,Values=${VPCID} --query "$(query_filter "${INSTANCE_WHITELIST}") [].{\"launch\": LaunchTime, \"aws_id\": InstanceId, \"bosh_id\": Tags[?Key==\`id\`].Value | [0]} | [].[bosh_id, aws_id, launch]"); do
+
+    bosh_id=$(echo ${vminfo} | cut -f1)
+    aws_id=$(echo ${vminfo} | cut -f2)
+    launch=$(echo ${vminfo} | cut -f3)
+
+    ${RIEMANNC} --service "aws.ec2.describe-instances" --host ${bosh_id} --attributes instance_id=${aws_id} --ttl 120 --metric_sint64 $(($(date +%s) - $(date -d"${launch}" +%s)))
 done
 
 ${RIEMANNC} --service "unknown-vm.check" --host $(hostname) --ttl 300 --metric_sint64 1

--- a/cronjobs/unknown-vms.sh
+++ b/cronjobs/unknown-vms.sh
@@ -57,7 +57,7 @@ for vminfo in $(${AWSCLI} ec2 describe-instances --max-items 500 --output text  
     aws_id=$(echo ${vminfo} | cut -f2)
     launch=$(echo ${vminfo} | cut -f3)
 
-    ${RIEMANNC} --service "aws.ec2.describe-instances" --host ${bosh_id} --attributes instance_id=${aws_id} --ttl 120 --metric_sint64 $(($(date +%s) - $(date -d"${launch}" +%s)))
+    ${RIEMANNC} --service "aws.ec2.describe-instances" --host ${aws_id} --attributes bosh_id=${bosh_id} --ttl 120 --metric_sint64 $(($(date +%s) - $(date -d"${launch}" +%s)))
 done
 
 ${RIEMANNC} --service "unknown-vm.check" --host $(hostname) --ttl 300 --metric_sint64 1


### PR DESCRIPTION
This PR extends the `unknown-vms` cron job to emit a metric for each IaaS instance with it's uptime.  

These metrics will be used by riemann to know which systems must be monitored for active log activity for  https://github.com/18F/cg-product/issues/476