### PR TITLE
Update ntp server for AU-8

### DIFF
--- a/bosh-deployment.yml
+++ b/bosh-deployment.yml
@@ -210,7 +210,7 @@ properties:
 
   agent:
     mbus: (( concat "nats://nats:" meta.passwords.nats-password "@" meta.default_static_ip ":4222" ))
-  ntp: &ntp [north-america.pool.ntp.org, europe.pool.ntp.org, oceania.pool.ntp.org]
+  ntp: &ntp [time.nist.gov]
 
   uaa:
     url: (( concat "https://" meta.default_static_ip ":8443" ))

--- a/bosh-init-deployment.yml
+++ b/bosh-init-deployment.yml
@@ -167,7 +167,7 @@ jobs:
     agent:
       mbus: (( concat "nats://nats:" meta.passwords.nats-password "@" meta.default_static_ip ":4222" ))
 
-    ntp: &ntp [north-america.pool.ntp.org, europe.pool.ntp.org, oceania.pool.ntp.org]
+    ntp: &ntp [time.nist.gov]
 
 cloud_provider:
   template: {name: aws_cpi, release: bosh-aws-cpi}


### PR DESCRIPTION
A nist AU-8 update to the NTP urls to use NIST timeservers as our `SYNCHRONIZATION WITH AUTHORITATIVE TIME SOURCE`
http://tf.nist.gov/tf-cgi/servers.cgi