### PR TITLE
Drop redis from master-bosh config.

### DIFF
--- a/bosh-init-deployment.yml
+++ b/bosh-init-deployment.yml
@@ -10,7 +10,6 @@ meta:
     availability_zone: ~
   passwords:
     nats-password: ~
-    redis-password: ~
     postgres-password: ~
     admin-password: ~
     director-password: ~
@@ -66,7 +65,6 @@ jobs:
   templates:
   - {name: nats, release: bosh}
   - {name: powerdns, release: bosh}
-  - {name: redis, release: bosh}
   - {name: postgres, release: bosh}
   - {name: blobstore, release: bosh}
   - {name: director, release: bosh}
@@ -87,11 +85,6 @@ jobs:
       address: 127.0.0.1
       user: nats
       password: (( grab meta.passwords.nats-password ))
-
-    redis:
-      listen_address: 127.0.0.1
-      address: 127.0.0.1
-      password: (( grab meta.passwords.redis-password ))
 
     postgres: &bosh_db
       listen_address: 127.0.0.1

--- a/bosh-init-secrets.example.yml
+++ b/bosh-init-secrets.example.yml
@@ -6,7 +6,6 @@ meta:
     availability_zone: us-west-1a
   passwords:
     nats-password: NATS_PASSWORD
-    redis-password: REDIS_PASSWORD
     postgres-password: POSTGRES_PASSWORD
     admin-password: ADMIN_PASSWORD
     director-password: DIRECTOR_PASSWORD

--- a/secrets.example.yml
+++ b/secrets.example.yml
@@ -23,7 +23,6 @@ meta:
   bosh_domain_name: bosh
   passwords:
     nats-password: NATS_PASSWORD
-    redis-password: REDIS_PASSWORD
     admin-password: ADMIN_PASSWORD
     director-password: DIRECTOR_PASSWORD
     agent-password: AGENT_PASSWORD


### PR DESCRIPTION
Because bosh doesn't use or package it anymore. h/t @LinuxBozo