### PR TITLE
Drop single and double quotes from release versions.

### DIFF
--- a/update-runtime-config.sh
+++ b/update-runtime-config.sh
@@ -21,7 +21,7 @@ pushd releases
     pushd ${release}
       tar xf *.tgz
       release=$(grep "^name" release.MF | awk '{print $2}')
-      version=$(grep "^version" release.MF | awk '{print $2}' | sed -e "s/'//g")
+      version=$(grep "^version" release.MF | awk '{print $2}' | sed -e "s/['\"']//g")
       declare -x "release_${release//-/_}"=${version}
     popd
   done


### PR DESCRIPTION
Because our releases include versions wrapped in both single and double quotes--not sure why.

```
root@d3bc6a93-0fcf-48ed-5c89-5b7eb3e7d8da:/tmp/build/59447205# grep -R "^version" releases
releases/fisma/release.MF:version: '15'
releases/tripwire/release.MF:version: '16'
releases/awslogs/release.MF:version: "17"
releases/nessus-agent/release.MF:version: '15'
releases/newrelic/release.MF:version: '15'
releases/clamav/release.MF:version: '7'
releases/snort/release.MF:version: '47'
releases/riemannc/release.MF:version: "9"
releases/riemann/release.MF:version: 0.16.83
releases/collectd/release.MF:version: '14'
releases/cron/release.MF:version: 1.1.1
```