### PR TITLE
Remove addons related to cron

### DIFF
--- a/bosh-deployment.yml
+++ b/bosh-deployment.yml
@@ -35,6 +35,8 @@ releases:
   version: latest
 - name: uaa
   version: latest
+- name: cron,
+  version: latest
 
 compilation:
   workers: 3
@@ -70,6 +72,7 @@ jobs:
   - {name: powerdns, release: bosh}
   - {name: aws_cpi, release: bosh-aws-cpi}
   - {name: uaa, release: uaa}
+  - {name: cron, release: cron}
 
   instances: 1
   resource_pool: large

--- a/runtime-config.yml
+++ b/runtime-config.yml
@@ -8,7 +8,6 @@ releases:
 - {name: collectd, version: (( grab $release_collectd ))}
 - {name: nessus-agent, version: (( grab $release_nessus_agent ))}
 - {name: riemannc, version: (( grab $release_riemannc ))}
-- {name: cron, version: (( grab $release_cron ))}
 
 addons:
 - name: hardening

--- a/update-runtime-config.yml
+++ b/update-runtime-config.yml
@@ -18,7 +18,6 @@ inputs:
 - {name: cg-s3-riemannc-release, path: releases/riemannc}
 - {name: cg-s3-riemann-release, path: releases/riemann}
 - {name: cg-s3-collectd-release, path: releases/collectd}
-- {name: cron-release, path: releases/cron}
 
 run:
   path: bosh-config/update-runtime-config.sh


### PR DESCRIPTION
Removing cron from the addons configuration for bosh deployments. This means we'll need to bring them back in the repos that use them. Those PRs are cross-linked below. 👇 

🎩 💁‍♂️ to @cnelson and this [Github search query](https://github.com/search?l=YAML&p=2&q=user%3A18F+cron%3A&ref=searchresults&type=Code&utf8=%E2%9C%93).