### PR TITLE
Update bosh config paths.

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -764,6 +764,7 @@ resources:
     - update-runtime-config.yml
     - update-runtime-config.sh
     - runtime-config.yml
+    - tooling-uaa.yml
     - cronjobs/*
 
 - name: bosh-init-config


### PR DESCRIPTION
So that concourse notices when the opslogin uaa clients change.