### PR TITLE
move logsearch network to services

### DIFF
--- a/cloud-config/cloud-config-main.yml
+++ b/cloud-config/cloud-config-main.yml
@@ -45,15 +45,15 @@ networks:
   type: manual
   subnets:
   - az: z1
-    range: (( grab terraform_outputs.public_subnet_cidr_az1 ))
-    gateway: (( grab terraform_outputs.public_subnet_gateway_az1 ))
+    range: (( grab terraform_outputs.services_subnet_cidr_az1 ))
+    gateway: (( grab terraform_outputs.services_subnet_gateway_az1 ))
     reserved:
-    - (( grab terraform_outputs.public_subnet_reserved_az1 ))
+    - (( grab terraform_outputs.services_subnet_reserved_az1 ))
     static: (( grab terraform_outputs.logsearch_static_ips ))
     dns:
     - (( grab terraform_outputs.vpc_cidr_dns ))
     cloud_properties:
-      subnet: (( grab terraform_outputs.public_subnet_az1 ))
+      subnet: (( grab terraform_outputs.services_subnet_az1 ))
       security_groups:
       - (( grab terraform_outputs.bosh_security_group ))
 


### PR DESCRIPTION
Logsearch network in cloud config needs to point to services subnet.
Goes with https://github.com/18F/cg-provision/pull/260