### PR TITLE
Rename logsearch network to services

### DIFF
--- a/cloud-config/cloud-config-main.yml
+++ b/cloud-config/cloud-config-main.yml
@@ -41,7 +41,7 @@ networks:
       security_groups:
       - (( grab terraform_outputs.bosh_security_group ))
       - (( grab terraform_outputs.concourse_security_group ))
-- name: logsearch
+- name: services 
   type: manual
   subnets:
   - az: z1


### PR DESCRIPTION
Rename logsearch network to something we can use for all deployments in services subnet
PR to update logsearch deployment: https://github.com/18F/cg-deploy-logsearch/pull/71