### PR TITLE
Align parser instance type with workload

### DIFF
--- a/cloud-config/cloud-config-main.yml
+++ b/cloud-config/cloud-config-main.yml
@@ -100,7 +100,7 @@ vm_types:
     instance_type: t2.medium
 - name: logsearch_parser
   cloud_properties:
-    instance_type: c4.xlarge
+    instance_type: r4.large
 - name: logsearch_kibana
   cloud_properties:
     instance_type: t2.medium


### PR DESCRIPTION
I think we should change the instance type from 4 vCPU/7.5GB RAM to 2 vCPUs/15GB RAM.

The elasticsearch instance running on the parser has been consuming more memory since moving to ES5.X, frequently using > 90% of memory, and occasionally starting to swap, however the CPU usage does not climb above 20%: 

<img width="892" alt="screen shot 2017-06-19 at 14 31 45" src="https://user-images.githubusercontent.com/604163/27306844-20b84f02-54fc-11e7-857e-e271484a8cbe.png">

Swapping CPUs for more memory and saving ~ $1400/yr seems like the right approach to me