### PR TITLE
Bump influxdb disk

### DIFF
--- a/cloud-config/cloud-config-tooling.yml
+++ b/cloud-config/cloud-config-tooling.yml
@@ -241,7 +241,7 @@ disk_types:
     encrypted: true
 - &monitoring-influxdb-disk
   name: staging-monitoring-influxdb
-  disk_size: 200000
+  disk_size: 250000
   cloud_properties:
     type: gp2
     encrypted: true


### PR DESCRIPTION
Decided to make this permanent;  Even with retention policy being properly applied, we are still > 170GB