### PR TITLE
Build logsearch bosh releases.

### DIFF
--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -51,3 +51,9 @@ releases:
 - name: kubernetes
   uri: https://github.com/18F/kubernetes-release
   branch: master
+- name: logsearch
+  uri: https://github.com/18F/logsearch-boshrelease
+  branch: develop
+- name: logsearch-for-cloudfoundry
+  uri: https://github.com/18F/logsearch-for-cloudfoundry
+  branch: develop


### PR DESCRIPTION
Standardize on 18F forks of logsearch releases. We should still decide how we're going to keep these up to date.