### PR TITLE
Update logsearch cloud config for latest releases.

### DIFF
--- a/cloud-config/cloud-config-development.yml
+++ b/cloud-config/cloud-config-development.yml
@@ -23,9 +23,6 @@ vm_types:
 - name: logsearch_cluster_monitor
   cloud_properties:
     instance_type: t2.large
-- name: logsearch_haproxy
-  cloud_properties:
-    instance_type: t2.large
 - name: kubernetes_consul
   cloud_properties:
     instance_type: t2.large

--- a/cloud-config/cloud-config-main.yml
+++ b/cloud-config/cloud-config-main.yml
@@ -110,9 +110,6 @@ vm_types:
 - name: logsearch_cluster_monitor
   cloud_properties:
     instance_type: m3.xlarge
-- name: logsearch_haproxy
-  cloud_properties:
-    instance_type: t2.medium
 - name: kubernetes_consul
   cloud_properties:
     instance_type: m3.large
@@ -144,6 +141,11 @@ disk_types:
     encrypted: true
 - name: logsearch_es_data
   disk_size: 1500000
+  cloud_properties:
+    type: gp2
+    encrypted: true
+- name: logsearch_ingestor
+  disk_size: 8192
   cloud_properties:
     type: gp2
     encrypted: true

--- a/cloud-config/cloud-config-main.yml
+++ b/cloud-config/cloud-config-main.yml
@@ -97,7 +97,7 @@ vm_types:
     instance_type: t2.2xlarge
 - name: logsearch_ingestor
   cloud_properties:
-    instance_type: t2.medium
+    instance_type: r4.large
 - name: logsearch_parser
   cloud_properties:
     instance_type: r4.large
@@ -145,7 +145,7 @@ disk_types:
     type: gp2
     encrypted: true
 - name: logsearch_ingestor
-  disk_size: 8192
+  disk_size: 32_000
   cloud_properties:
     type: gp2
     encrypted: true

--- a/cloud-config/cloud-config-main.yml
+++ b/cloud-config/cloud-config-main.yml
@@ -174,6 +174,10 @@ vm_extensions:
   cloud_properties:
     elbs:
     - (( grab terraform_outputs.shibboleth_elb_name ))
+- name: logsearch-lb
+  cloud_properties:
+    elbs:
+    - (( grab terraform_outputs.logsearch_elb_name ))
 - name: kubernetes-lb
   cloud_properties:
     elbs:


### PR DESCRIPTION
Goes with https://github.com/18F/cg-deploy-logsearch/pull/83.

* Drop unused vm type
* Add ingestor persistent disk