### PR TITLE
Build secureproxy in its own pipeline.

### DIFF
--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -11,9 +11,6 @@ releases:
 - name: riemann
   uri: https://github.com/18F/cg-riemann-boshrelease
   branch: master
-- name: secureproxy
-  uri: https://github.com/18F/cg-secureproxy-boshrelease
-  branch: master
 - name: awslogs
   uri: https://github.com/18F/cg-awslogs-boshrelease
   branch: master


### PR DESCRIPTION
Goes with https://github.com/18F/cg-secureproxy-boshrelease/pull/19.