### PR TITLE
Bump prometheus disk.

### DIFF
--- a/cloud-config/cloud-config-tooling.yml
+++ b/cloud-config/cloud-config-tooling.yml
@@ -219,7 +219,7 @@ disk_types:
     encrypted: true
 - &prometheus-large-disk
   name: staging-prometheus-large
-  disk_size: 50_001
+  disk_size: 64_000
   cloud_properties:
     type: gp2
     encrypted: true


### PR DESCRIPTION
Prometheus production is currently at 90%; this will drop usage to 70%.