### PR TITLE
Use bosh.io release instead of building from github.  This way the bl…

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -127,6 +127,8 @@ jobs:
       trigger: true
     - get: cron-release
       trigger: true
+    - get: ntp-release
+      trigger: true
     - get: node-exporter-release
       trigger: true
     - get: syslog-release
@@ -153,6 +155,7 @@ jobs:
       - {name: cg-s3-riemann-release, path: releases/riemann}
       - {name: cg-s3-collectd-release, path: releases/collectd}
       - {name: cron-release, path: releases/cron}
+      - {name: ntp-release, path: releases/ntp}
       - {name: node-exporter-release, path: releases/node-exporter}
       - {name: syslog-release, path: releases/syslog}
       params:
@@ -294,6 +297,8 @@ jobs:
       trigger: true
     - get: cron-release
       trigger: true
+    - get: ntp-release
+      trigger: true
     - get: node-exporter-release
       trigger: true
     - get: syslog-release
@@ -430,6 +435,8 @@ jobs:
     - get: cg-s3-collectd-release
       trigger: true
     - get: cron-release
+      trigger: true
+    - get: ntp-release
       trigger: true
     - get: node-exporter-release
       trigger: true
@@ -594,6 +601,8 @@ jobs:
       trigger: true
     - get: cron-release
       trigger: true
+    - get: ntp-release
+      trigger: true
     - get: node-exporter-release
       trigger: true
     - get: syslog-release
@@ -658,6 +667,8 @@ jobs:
     - get: cg-s3-collectd-release
       trigger: true
     - get: cron-release
+      trigger: true
+    - get: ntp-release
       trigger: true
     - get: syslog-release
       trigger: true
@@ -850,6 +861,11 @@ resources:
   type: bosh-io-release
   source:
     repository: cloudfoundry-community/cron-boshrelease
+
+- name: ntp-release
+  type: bosh-io-release
+  source:
+    repository: cloudfoundry-community/ntp-boshrelease
 
 - name: syslog-release
   type: bosh-io-release

--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -60,6 +60,3 @@ releases:
 - name: oauth2-proxy
   uri: https://github.com/18F/oauth2-proxy-boshrelease
   branch: master
-- name: ntp
-  uri: https://github.com/cloudfoundry-community/ntp-release
-  branch: master


### PR DESCRIPTION
…obstore doesn't require magic.