### PR TITLE
Fix concourse deprecation error.

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -731,12 +731,10 @@ jobs:
     - get: master-bosh-root-cert
   - task: decrypt-private-key
     file: pipeline-tasks/decrypt.yml
-    config:
-      inputs:
-      - name: pipeline-tasks
-      - name: common-masterbosh
+    input_mapping:
+      encrypt: common-masterbosh
     params:
-      INPUT_FILE: common-masterbosh/boshCA.crt
+      INPUT_FILE: encrypt/boshCA.crt
       OUTPUT_FILE: decrypt/master-bosh.pem
       PASSPHRASE: {{masterbosh-secrets-passphrase}}
   - task: bosh-create-env


### PR DESCRIPTION
Because the deprecation warning about specifying both `file` and `config` on a task is now a deprecation error. Depends on https://github.com/18F/cg-pipeline-tasks/pull/57.