### PR TITLE
Revert "Enable uniqueness restriction on refresh tokens."

### DIFF
--- a/bosh-deployment.yml
+++ b/bosh-deployment.yml
@@ -187,9 +187,6 @@ instance_groups:
         jwt:
           signing_key: (( grab secrets.bosh_uaa_web_key ))
           verification_key: (( grab secrets.bosh_uaa_web_public_key ))
-          revocable: true
-          refresh:
-            unique: true
         admin:
           client_secret: (( grab secrets.bosh_uaa_admin_client_secret ))
         login:


### PR DESCRIPTION
Reverts 18F/cg-deploy-bosh#181

> Multiple ci jobs use a shared uaa client to auth to bosh, and it looks like they're invalidating each others' tokens.