### PR TITLE
Authenticate to bosh using uaa client credentials.

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1021,8 +1021,8 @@ resources:
   type: bosh-deployment
   source:
     target: {{toolingbosh-target}}
-    client: {{toolingbosh-username}}
-    client_secret: {{toolingbosh-password}}
+    client: {{toolingbosh-uaa-client}}
+    client_secret: {{toolingbosh-uaa-client-secret}}
     ca_cert: {{toolingbosh-ca-cert}}
     deployment: developmentbosh
 
@@ -1030,8 +1030,8 @@ resources:
   type: bosh-deployment
   source:
     target: {{toolingbosh-target}}
-    client: {{toolingbosh-username}}
-    client_secret: {{toolingbosh-password}}
+    client: {{toolingbosh-uaa-client}}
+    client_secret: {{toolingbosh-uaa-client-secret}}
     ca_cert: {{toolingbosh-ca-cert}}
     deployment: stagingbosh
 
@@ -1039,8 +1039,8 @@ resources:
   type: bosh-deployment
   source:
     target: {{toolingbosh-target}}
-    client: {{toolingbosh-username}}
-    client_secret: {{toolingbosh-password}}
+    client: {{toolingbosh-uaa-client}}
+    client_secret: {{toolingbosh-uaa-client-secret}}
     ca_cert: {{toolingbosh-ca-cert}}
     deployment: productionbosh
 


### PR DESCRIPTION
Because password authentication to tooling bosh doesn't appear to work after switching to the latest bosh-deployment-resource.