### PR TITLE
Ignore masterbosh and the main VPC bosh in the unknown vm check

### DIFF
--- a/bosh-deployment.yml
+++ b/bosh-deployment.yml
@@ -272,7 +272,8 @@ instance_groups:
           PGDBNAME: bosh
           VPC_NAME: (( grab terraform_outputs.stack_description ))
           BOSH_DIRECTOR: (( grab terraform_outputs.bosh_static_ip ))
-          INSTANCE_WHITELIST: (( concat terraform_outputs.nat_private_ip_az1 " " terraform_outputs.nat_private_ip_az2 ))
+          INSTANCE_WHITELIST: (( concat terraform_outputs.nat_private_ip_az1 " " terraform_outputs.nat_private_ip_az2 " " terraform_outputs.
+            master_bosh_static_ip " " terraform_outputs.bosh_static_ip ))
         entries:
         - script:
             name: unknown-vms.sh


### PR DESCRIPTION
Since bosh is deployed from another bosh, it won't know about itself during the VM check, so make sure we ignore it. Also, always ignore masterbosh, since we know it will exist and isn't tracked by another bosh.