### PR TITLE
Stop running new relic agent on every host.

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -120,8 +120,6 @@ jobs:
       trigger: true
     - get: cg-s3-nessus-agent-release
       trigger: true
-    - get: cg-s3-newrelic-release
-      trigger: true
     - get: cg-s3-clamav-release
       trigger: true
     - get: cg-s3-snort-release
@@ -157,7 +155,6 @@ jobs:
       - {name: cg-s3-tripwire-release, path: releases/tripwire}
       - {name: cg-s3-awslogs-release, path: releases/awslogs}
       - {name: cg-s3-nessus-agent-release, path: releases/nessus-agent}
-      - {name: cg-s3-newrelic-release, path: releases/newrelic}
       - {name: cg-s3-clamav-release, path: releases/clamav}
       - {name: cg-s3-snort-release, path: releases/snort}
       - {name: cg-s3-riemannc-release, path: releases/riemannc}
@@ -193,7 +190,6 @@ jobs:
       TRIPWIRE_LOCALPASS: {{tripwire-localpass-development}}
       TRIPWIRE_SITEPASS: {{tripwire-sitepass-development}}
       AWS_REGION: {{aws-region-development}}
-      NEWRELIC_LICENSE_KEY: {{newrelic-license-key-development}}
       NESSUS_AGENT_KEY: {{nessus-agent-key-development}}
       NESSUS_AGENT_SERVER: {{nessus-agent-server-development}}
       NESSUS_AGENT_PORT: {{nessus-agent-port-development}}
@@ -300,8 +296,6 @@ jobs:
       trigger: true
     - get: cg-s3-nessus-agent-release
       trigger: true
-    - get: cg-s3-newrelic-release
-      trigger: true
     - get: cg-s3-clamav-release
       trigger: true
     - get: cg-s3-snort-release
@@ -343,7 +337,6 @@ jobs:
       TRIPWIRE_LOCALPASS: {{tripwire-localpass-staging}}
       TRIPWIRE_SITEPASS: {{tripwire-sitepass-staging}}
       AWS_REGION: {{aws-region-staging}}
-      NEWRELIC_LICENSE_KEY: {{newrelic-license-key-staging}}
       NESSUS_AGENT_KEY: {{nessus-agent-key-staging}}
       NESSUS_AGENT_SERVER: {{nessus-agent-server-staging}}
       NESSUS_AGENT_PORT: {{nessus-agent-port-staging}}
@@ -448,8 +441,6 @@ jobs:
       trigger: true
     - get: cg-s3-nessus-agent-release
       trigger: true
-    - get: cg-s3-newrelic-release
-      trigger: true
     - get: cg-s3-clamav-release
       trigger: true
     - get: cg-s3-snort-release
@@ -491,7 +482,6 @@ jobs:
       TRIPWIRE_LOCALPASS: {{tripwire-localpass-production}}
       TRIPWIRE_SITEPASS: {{tripwire-sitepass-production}}
       AWS_REGION: {{aws-region-production}}
-      NEWRELIC_LICENSE_KEY: {{newrelic-license-key-production}}
       NESSUS_AGENT_KEY: {{nessus-agent-key-production}}
       NESSUS_AGENT_SERVER: {{nessus-agent-server-production}}
       NESSUS_AGENT_PORT: {{nessus-agent-port-production}}
@@ -622,8 +612,6 @@ jobs:
       trigger: true
     - get: cg-s3-nessus-agent-release
       trigger: true
-    - get: cg-s3-newrelic-release
-      trigger: true
     - get: cg-s3-clamav-release
       trigger: true
     - get: cg-s3-snort-release
@@ -653,7 +641,6 @@ jobs:
       - {name: cg-s3-tripwire-release, path: releases/tripwire}
       - {name: cg-s3-awslogs-release, path: releases/awslogs}
       - {name: cg-s3-nessus-agent-release, path: releases/nessus-agent}
-      - {name: cg-s3-newrelic-release, path: releases/newrelic}
       - {name: cg-s3-clamav-release, path: releases/clamav}
       - {name: cg-s3-snort-release, path: releases/snort}
       - {name: cg-s3-riemannc-release, path: releases/riemannc}
@@ -680,7 +667,6 @@ jobs:
       TRIPWIRE_LOCALPASS: {{tripwire-localpass-tooling}}
       TRIPWIRE_SITEPASS: {{tripwire-sitepass-tooling}}
       AWS_REGION: {{aws-region-tooling}}
-      NEWRELIC_LICENSE_KEY: {{newrelic-license-key-tooling}}
       NESSUS_AGENT_KEY: {{nessus-agent-key-tooling}}
       NESSUS_AGENT_SERVER: {{nessus-agent-server-tooling}}
       NESSUS_AGENT_PORT: {{nessus-agent-port-tooling}}
@@ -704,8 +690,6 @@ jobs:
     - get: cg-s3-awslogs-release
       trigger: true
     - get: cg-s3-nessus-agent-release
-      trigger: true
-    - get: cg-s3-newrelic-release
       trigger: true
     - get: cg-s3-clamav-release
       trigger: true
@@ -736,7 +720,6 @@ jobs:
       - {name: cg-s3-tripwire-release, path: releases/tripwire}
       - {name: cg-s3-awslogs-release, path: releases/awslogs}
       - {name: cg-s3-nessus-agent-release, path: releases/nessus-agent}
-      - {name: cg-s3-newrelic-release, path: releases/newrelic}
       - {name: cg-s3-clamav-release, path: releases/clamav}
       - {name: cg-s3-snort-release, path: releases/snort}
       - {name: cg-s3-riemannc-release, path: releases/riemannc}
@@ -763,7 +746,6 @@ jobs:
       TRIPWIRE_LOCALPASS: {{tripwire-localpass-master}}
       TRIPWIRE_SITEPASS: {{tripwire-sitepass-master}}
       AWS_REGION: {{aws-region-master}}
-      NEWRELIC_LICENSE_KEY: {{newrelic-license-key-master}}
       NESSUS_AGENT_KEY: {{nessus-agent-key-master}}
       NESSUS_AGENT_SERVER: {{nessus-agent-server-master}}
       NESSUS_AGENT_PORT: {{nessus-agent-port-master}}
@@ -1077,12 +1059,6 @@ resources:
   type: s3-iam
   source:
     regexp: nessus-agent-(.*).tgz
-    <<: *s3-release-params
-
-- name: cg-s3-newrelic-release
-  type: s3-iam
-  source:
-    regexp: newrelic-(.*).tgz
     <<: *s3-release-params
 
 - name: cg-s3-clamav-release

--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -26,9 +26,6 @@ releases:
 - name: nessus-manager
   uri: https://github.com/18F/cg-nessus-manager-boshrelease
   branch: master
-- name: newrelic
-  uri: https://github.com/cloudfoundry-community/newrelic-boshrelease
-  branch: master
 - name: node-exporter
   uri: https://github.com/cloudfoundry-community/node-exporter-boshrelease
   branch: master

--- a/runtime-config/base.yml
+++ b/runtime-config/base.yml
@@ -4,7 +4,6 @@ releases:
 - {name: clamav, version: (( grab $release_clamav ))}
 - {name: snort, version: (( grab $release_snort ))}
 - {name: awslogs, version: (( grab $release_awslogs ))}
-- {name: newrelic, version: (( grab $release_newrelic ))}
 - {name: collectd, version: (( grab $release_collectd ))}
 - {name: nessus-agent, version: (( grab $release_nessus_agent ))}
 - {name: riemannc, version: (( grab $release_riemannc ))}
@@ -19,7 +18,6 @@ addons:
   - {name: clamav, release: clamav}
   - {name: snort, release: snort}
   - {name: awslogs, release: awslogs}
-  - {name: newrelic-monitor, release: newrelic}
   - {name: nessus-agent, release: nessus-agent}
   - {name: collectd, release: collectd}
   - {name: riemannc, release: riemannc}
@@ -31,8 +29,6 @@ addons:
       sitepass: (( grab $TRIPWIRE_SITEPASS ))
     awslogs:
       region: (( grab $AWS_REGION ))
-    newrelic:
-      license_key: (( grab $NEWRELIC_LICENSE_KEY ))
     nessus-agent:
       key: (( grab $NESSUS_AGENT_KEY ))
       server: (( grab $NESSUS_AGENT_SERVER ))

--- a/update-runtime-config-tooling.yml
+++ b/update-runtime-config-tooling.yml
@@ -13,7 +13,6 @@ inputs:
 - {name: cg-s3-tripwire-release, path: releases/tripwire}
 - {name: cg-s3-awslogs-release, path: releases/awslogs}
 - {name: cg-s3-nessus-agent-release, path: releases/nessus-agent}
-- {name: cg-s3-newrelic-release, path: releases/newrelic}
 - {name: cg-s3-clamav-release, path: releases/clamav}
 - {name: cg-s3-snort-release, path: releases/snort}
 - {name: cg-s3-riemannc-release, path: releases/riemannc}

--- a/update-runtime-config.yml
+++ b/update-runtime-config.yml
@@ -13,7 +13,6 @@ inputs:
 - {name: cg-s3-tripwire-release, path: releases/tripwire}
 - {name: cg-s3-awslogs-release, path: releases/awslogs}
 - {name: cg-s3-nessus-agent-release, path: releases/nessus-agent}
-- {name: cg-s3-newrelic-release, path: releases/newrelic}
 - {name: cg-s3-clamav-release, path: releases/clamav}
 - {name: cg-s3-snort-release, path: releases/snort}
 - {name: cg-s3-riemannc-release, path: releases/riemannc}


### PR DESCRIPTION
Because we're only using this to report system metrics we already get from bosh health monitor and collectd. Note: we'll continue using new relic for specific applications, just not on every bosh vm.