### PR TITLE
Drop riemann health monitor plugin.

### DIFF
--- a/bosh-deployment.yml
+++ b/bosh-deployment.yml
@@ -114,7 +114,6 @@ instance_groups:
         resurrector_enabled: true
         resurrector:
           minimum_down_jobs: 3
-        riemann_enabled: true
       nats: (( grab instance_groups.bosh.jobs.nats.properties.nats ))
       director:
         address: (( grab terraform_outputs.bosh_static_ip ))


### PR DESCRIPTION
This hasn't been working for a while, and it's already covered by prometheus. It's also sending millions of error logs per day. Let's drop it.