### PR TITLE
Increase piops to 14000 to handle metric load

### DIFF
--- a/cloud-config/cloud-config-tooling.yml
+++ b/cloud-config/cloud-config-tooling.yml
@@ -173,7 +173,7 @@ disk_types:
   name: production-prometheus-large
   cloud_properties:
     type: io1
-    iops: 9_000
-
+    iops: 14_000
+    size: 300_000
 compilation:
   network: production-concourse


### PR DESCRIPTION
At 900 we still are entering rushed storage mode and dropping ~hundreds