### PR TITLE
Drop instance types on development and staging.

### DIFF
--- a/cloud-config/cloud-config-development.yml
+++ b/cloud-config/cloud-config-development.yml
@@ -2,63 +2,36 @@ vm_types:
 - name: logsearch_es_master
   cloud_properties:
     instance_type: t2.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: logsearch_es_data
   cloud_properties:
     instance_type: t2.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: logsearch_queue
   cloud_properties:
     instance_type: t2.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: logsearch_ingestor
   cloud_properties:
     instance_type: t2.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: logsearch_parser
   cloud_properties:
     instance_type: t2.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: logsearch_kibana
   cloud_properties:
     instance_type: t2.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: logsearch_maintenance
   cloud_properties:
     instance_type: t2.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: logsearch_cluster_monitor
   cloud_properties:
     instance_type: t2.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: kubernetes_consul
   cloud_properties:
     instance_type: t2.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: kubernetes_etcd
   cloud_properties:
     instance_type: t2.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
+- name: kubernetes_minion
+  cloud_properties:
+    instance_type: r4.large
 
 disk_types:
 - name: logsearch_es_data

--- a/cloud-config/cloud-config-staging.yml
+++ b/cloud-config/cloud-config-staging.yml
@@ -1,14 +1,20 @@
-disk_types:
-- name: logsearch_es_data
-  disk_size: 150000
-  cloud_properties:
-    type: gp2
-    encrypted: true
-
 vm_types:
 - name: logsearch_es_data
   cloud_properties:
     instance_type: t2.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
+- name: kubernetes_consul
+  cloud_properties:
+    instance_type: t2.large
+- name: kubernetes_etcd
+  cloud_properties:
+    instance_type: t2.large
+- name: kubernetes_minion
+  cloud_properties:
+    instance_type: r4.large
+- name: concourse-worker
+  cloud_properties:
+    instance_type: m3.medium
+
+disk_types:
+- name: logsearch_es_data
+  disk_size: 150000


### PR DESCRIPTION
Save money on instances we hardly use.