### PR TITLE
Disks are encrypted by default.

### DIFF
--- a/cloud-config/cf.yml
+++ b/cloud-config/cf.yml
@@ -3,109 +3,65 @@ vm_types:
   cloud_properties:
     instance_type: m4.large
     ephemeral_disk:
-      type: gp2
-      encrypted: true
       size: 10240
 - name: small
   cloud_properties:
     instance_type: m4.large
     ephemeral_disk:
-      type: gp2
-      encrypted: true
       size: 10240
 - name: small-highmem
   cloud_properties:
     instance_type: r4.xlarge
     ephemeral_disk:
-      type: gp2
-      encrypted: true
       size: 10240
 
 disk_types:
 - name: default
   disk_size: 1024
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - name: 1GB
   disk_size: 1024
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - name: 5GB
   disk_size: 5120
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - name: 10GB
   disk_size: 10240
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - name: 50GB
   disk_size: 51200
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - name: 100GB
   disk_size: 102400
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - name: 500GB
   disk_size: 512000
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - name: 1TB
   disk_size: 1048576
-  cloud_properties:
-    type: gp2
-    encrypted: true
 
 vm_extensions:
 # Ephemeral disks
 - name: 1GB_ephemeral_disk
   cloud_properties:
     ephemeral_disk:
-      type: gp2
-      encrypted: true
       size: 1024
 - name: 5GB_ephemeral_disk
   cloud_properties:
     ephemeral_disk:
-      type: gp2
-      encrypted: true
       size: 1024
 - name: 10GB_ephemeral_disk
   cloud_properties:
     ephemeral_disk:
-      type: gp2
-      encrypted: true
       size: 10240
 - name: 50GB_ephemeral_disk
   cloud_properties:
     ephemeral_disk:
-      type: gp2
-      encrypted: true
       size: 51200
 - name: 100GB_ephemeral_disk
   cloud_properties:
     ephemeral_disk:
-      type: gp2
-      encrypted: true
       size: 102400
 - name: 500GB_ephemeral_disk
   cloud_properties:
     ephemeral_disk:
-      type: gp2
-      encrypted: true
       size: 512000
 - name: 1TB_ephemeral_disk
   cloud_properties:
     ephemeral_disk:
-      type: gp2
-      encrypted: true
       size: 1048576
 # Load balancers
 - name: cf-router-network-properties

--- a/cloud-config/cloud-config-base.yml
+++ b/cloud-config/cloud-config-base.yml
@@ -16,21 +16,13 @@ vm_types:
     instance_type: c3.xlarge
     iam_instance_profile: (( grab terraform_outputs.bosh_compilation_profile ))
     ephemeral_disk:
-      type: gp2
       size: 30000
-      encrypted: true
 - name: errand_small
   cloud_properties:
     instance_type: t2.small
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: errand_large
   cloud_properties:
     instance_type: m4.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 
 vm_extensions:
 - name: errand-profile

--- a/cloud-config/cloud-config-main.yml
+++ b/cloud-config/cloud-config-main.yml
@@ -68,145 +68,79 @@ vm_types:
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk:
-      type: gp2
       size: 10240
-      encrypted: true
 - name: shibboleth
   cloud_properties:
     instance_type: m3.medium
     ephemeral_disk:
-      type: gp2
       size: 10240
-      encrypted: true
 - name: concourse-web
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk:
-      type: gp2
       size: 8_000
-      encrypted: true
 - name: concourse-worker
   cloud_properties:
     instance_type: m3.xlarge
     ephemeral_disk:
-      type: gp2
       size: 32_000
-      encrypted: true
 - name: logsearch_es_master
   cloud_properties:
     instance_type: t2.xlarge
     ephemeral_disk:
-      type: gp2
       size: 15000
-      encrypted: true
 - name: logsearch_es_data
   cloud_properties:
     instance_type: r4.xlarge
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: logsearch_redis
   cloud_properties:
     instance_type: t2.medium
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: logsearch_ingestor
   cloud_properties:
     instance_type: r4.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: logsearch_kibana
   cloud_properties:
     instance_type: t2.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: logsearch_maintenance
   cloud_properties:
     instance_type: t2.medium
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: kubernetes_consul
   cloud_properties:
     instance_type: m3.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: kubernetes_etcd
   cloud_properties:
     instance_type: t2.medium
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: kubernetes_master
   cloud_properties:
     instance_type: m3.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: kubernetes_minion
   cloud_properties:
     instance_type: r4.xlarge
     ephemeral_disk:
-      type: gp2
       size: 16_000
-      encrypted: true
 - name: nfs-volume
   cloud_properties:
     instance_type: m3.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 
 disk_types:
 - name: admin-ui
   disk_size: 5120
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - name: shibboleth
   disk_size: 4096
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - name: logsearch_es_master
   disk_size: 102400
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - name: logsearch_es_data
   disk_size: 2_500_000
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - name: logsearch_es_platform_data
   disk_size: 1_500_000
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - name: logsearch_ingestor
   disk_size: 35_000
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - name: logsearch_redis
   disk_size: 4096
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - name: kubernetes
   disk_size: 35_000
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - name: nfs-volume
   disk_size: 64_000
-  cloud_properties:
-    type: gp2
-    encrypted: true
 
 vm_extensions:
 - name: concourse-lb

--- a/cloud-config/cloud-config-master.yml
+++ b/cloud-config/cloud-config-master.yml
@@ -35,9 +35,6 @@ vm_extensions:
 disk_types:
 - name: bosh
   disk_size: 300000
-  cloud_properties:
-    type: gp2
-    encrypted: true
 
 compilation:
   network: bosh

--- a/cloud-config/cloud-config-tooling.yml
+++ b/cloud-config/cloud-config-tooling.yml
@@ -2,64 +2,41 @@ vm_types:
 - name: bosh
   cloud_properties:
     instance_type: m3.xlarge
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: nessus-manager
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk:
       size: 30000
-      type: gp2
-      encrypted: true
 - name: staging-prometheus-small
   cloud_properties:
     instance_type: t2.medium
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: staging-prometheus-large
   cloud_properties:
     instance_type: m4.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: production-prometheus-small
   cloud_properties:
     instance_type: m4.large
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - name: production-prometheus-large
   cloud_properties:
     instance_type: m4.2xlarge
-    ephemeral_disk:
-      type: gp2
-      encrypted: true
 - &concourse-web-vm
   name: staging-concourse-web
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk:
-      type: gp2
       size: 45000
-      encrypted: true
 - &concourse-worker-vm
   name: staging-concourse-worker
   cloud_properties:
     instance_type: m3.xlarge
     ephemeral_disk:
-      type: gp2
       size: 300000
-      encrypted: true
 - &concourse-iaas-worker-vm
   name: staging-concourse-iaas-worker
   cloud_properties:
     instance_type: m4.large
     ephemeral_disk:
-      type: gp2
       size: 300000
-      encrypted: true
 - <<: *concourse-web-vm
   name: production-concourse-web
 - <<: *concourse-worker-vm
@@ -191,26 +168,14 @@ vm_extensions:
 disk_types:
 - name: bosh
   disk_size: 16_000
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - name: nessus-manager
   disk_size: 120000
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - &prometheus-small-disk
   name: staging-prometheus-small
   disk_size: 2048
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - &prometheus-large-disk
   name: staging-prometheus-large
   disk_size: 200_000
-  cloud_properties:
-    type: gp2
-    encrypted: true
 - <<: *prometheus-small-disk
   name: production-prometheus-small
 - <<: *prometheus-large-disk


### PR DESCRIPTION
EBS volumes use gp2 by default (hard-coded in BOSH) and are encrypted by default (set in https://github.com/18F/cg-deploy-bosh/blob/master/bosh-deployment.yml#L251). We shouldn't need to copy default properties to each disk anymore.