### PR TITLE
Set default network to manual.

### DIFF
--- a/cloud-config/main.yml
+++ b/cloud-config/main.yml
@@ -1,6 +1,6 @@
 networks:
 - name: default
-  type: dynamic
+  type: manual
   subnets:
   - az: z1
     range: (( grab terraform_outputs.private_subnet_cidr_az1 ))


### PR DESCRIPTION
Avoid `IP address not available for the link provider` warnings on cf-deployment.