### PR TITLE
Add vm extension for *.18f.gov client elb.

### DIFF
--- a/cloud-config/cf.yml
+++ b/cloud-config/cf.yml
@@ -74,6 +74,10 @@ vm_extensions:
   cloud_properties:
     elbs:
     - (( grab terraform_outputs.diego_elb_name ))
+- name: star-18f-gov-elb
+  cloud_properties:
+    elbs: (( grab terraform_outputs.star_18f_gov_elb_name ))
+# Instance profiles
 - name: blobstore-profile
   cloud_properties:
     iam_instance_profile: (( grab terraform_outputs.cf_blobstore_profile ))


### PR DESCRIPTION
To restore *.18f.gov routes after migration to cf-deployment.