### PR TITLE
Make sure DNS private ips are in masterbosh reserve block

### DIFF
--- a/cloud-config/master.yml
+++ b/cloud-config/master.yml
@@ -11,9 +11,7 @@ networks:
     range: (( grab terraform_outputs.private_subnet_az1_cidr ))
     gateway: (( grab terraform_outputs.private_subnet_az1_gateway ))
     static: (( grab terraform_outputs.tooling_bosh_static_ip terraform_outputs.bosh_uaa_static_ips ))
-    reserved:
-    - (( grab terraform_outputs.private_subnet_az1_reserved ))
-    - (( grab terraform_outputs.master_bosh_static_ip ))
+    reserved: (( grab terraform_outputs.private_subnet_az1_reserved terraform_outputs.master_bosh_static_ip terraform_outputs.staging_dns_private_ips terraform_outputs.production_dns_private_ips ))
     dns:
     - (( grab terraform_outputs.vpc_cidr_dns ))
     cloud_properties:


### PR DESCRIPTION
Removes conflicts for compilation VMs when compiling toolingbosh packages from masterbosh.