### PR TITLE
Temporarily build prometheus release.

### DIFF
--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -48,3 +48,6 @@ releases:
 - name: pdns
   uri: https://github.com/18F/pdns-release
   branch: master
+- name: prometheus
+  uri: https://github.com/18F/prometheus-boshrelease
+  branch: prom2-job


### PR DESCRIPTION
Revert after upstream accepts prometheus 2.x patch.