### PR TITLE
Stop building custom grafana release.

### DIFF
--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -23,9 +23,6 @@ releases:
 - name: uaa-customized
   uri: https://github.com/18F/uaa-customized-boshrelease
   branch: master
-- name: grafana
-  uri: https://github.com/18F/cg-grafana-boshrelease
-  branch: master
   # waiting on upstream to merge fixes
 - name: admin-ui
   uri: https://github.com/jmcarp/admin-ui-boshrelease


### PR DESCRIPTION
We're using the grafana release bundled with prometheus-boshrelease now.