### PR TITLE
[WIP] Balance behind ALBs but not ELBs.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -382,7 +382,7 @@ jobs:
   - task: update-cloud-config
     file: bosh-config/ci/update-cloud-config.yml
     params:
-      MANIFEST_PATH: "bosh-config/cloud-config/main.yml bosh-config/cloud-config/cf.yml bosh-config/cloud-config/production.yml"
+      MANIFEST_PATH: "bosh-config/cloud-config/main.yml bosh-config/cloud-config/cf.yml"
       BOSH_CA_CERT: ca-cert-store/ca-cert-store.crt
       BOSH_ENVIRONMENT: ((productionbosh-target))
       BOSH_CLIENT: ci

--- a/cloud-config/cf.yml
+++ b/cloud-config/cf.yml
@@ -70,10 +70,6 @@ vm_extensions:
 # Load balancers
 - name: cf-router-network-properties
   cloud_properties:
-    elbs:
-    - (( grab terraform_outputs.cf_main_elb_name ))
-    - (( grab terraform_outputs.cf_apps_elb_name ))
-    - (( grab terraform_outputs.cf_logging_elb_name ))
     lb_target_groups:
     - (( grab terraform_outputs.cf_target_group ))
     - (( grab terraform_outputs.cf_apps_target_group ))

--- a/cloud-config/main.yml
+++ b/cloud-config/main.yml
@@ -116,8 +116,6 @@ disk_types:
 vm_extensions:
 - name: shibboleth-lb
   cloud_properties:
-    elbs:
-    - (( grab terraform_outputs.shibboleth_elb_name ))
     lb_target_groups:
     - (( grab terraform_outputs.shibboleth_lb_target_group ))
 - name: logsearch-lb
@@ -130,8 +128,6 @@ vm_extensions:
     - (( grab terraform_outputs.platform_syslog_elb_name ))
 - name: platform-kibana-lb
   cloud_properties:
-    elbs:
-    - (( grab terraform_outputs.platform_kibana_elb_name ))
     lb_target_groups:
     - (( grab terraform_outputs.platform_kibana_lb_target_group ))
 - name: kubernetes-lb

--- a/cloud-config/master.yml
+++ b/cloud-config/master.yml
@@ -26,8 +26,6 @@ vm_extensions:
     iam_instance_profile: (( grab terraform_outputs.bosh_profile ))
 - name: bosh-lb
   cloud_properties:
-    elbs:
-    - (( grab terraform_outputs.bosh_uaa_elb_name ))
     lb_target_groups:
     - (( grab terraform_outputs.opsuaa_target_group ))
 

--- a/cloud-config/production.yml
+++ b/cloud-config/production.yml
@@ -1,6 +1,0 @@
-vm_extensions:
-- name: cf-router-network-properties
-  cloud_properties:
-    elbs:
-    - (( append ))
-    - (( grab terraform_outputs.star_18f_gov_elb_name ))

--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -170,26 +170,18 @@ networks:
 vm_extensions:
 - name: nessus-manager-lb
   cloud_properties:
-    elbs:
-    - (( grab terraform_outputs.nessus_elb_name ))
     lb_target_groups:
     - (( grab terraform_outputs.nessus_target_group ))
 - name: staging-prometheus-lb
   cloud_properties:
-    elbs:
-    - (( grab terraform_outputs.staging_prometheus_elb_name ))
     lb_target_groups:
     - (( grab terraform_outputs.staging_monitoring_lb_target_group ))
 - name: production-prometheus-lb
   cloud_properties:
-    elbs:
-    - (( grab terraform_outputs.production_prometheus_elb_name ))
     lb_target_groups:
     - (( grab terraform_outputs.production_monitoring_lb_target_group ))
 - name: staging-concourse-lb
   cloud_properties:
-    elbs:
-    - (( grab terraform_outputs.staging_concourse_elb_name ))
     lb_target_groups:
     - (( grab terraform_outputs.staging_concourse_lb_target_group ))
 - &concourse-profile
@@ -202,8 +194,6 @@ vm_extensions:
     iam_instance_profile: (( grab terraform_outputs.concourse_iaas_worker_profile ))
 - name: production-concourse-lb
   cloud_properties:
-    elbs:
-    - (( grab terraform_outputs.production_concourse_elb_name ))
     lb_target_groups:
     - (( grab terraform_outputs.production_concourse_lb_target_group ))
 - <<: *concourse-profile


### PR DESCRIPTION
After https://github.com/18F/cg-provision/pull/382 is merged and DNS points to ALBs, we can drop public-facing ELBs from VM extensions. Don't merge until DNS is updated!