### PR TITLE
Update bosh release branches.

### DIFF
--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -45,13 +45,10 @@ releases:
   branch: master
 - name: oauth2-proxy
   uri: https://github.com/18F/oauth2-proxy-boshrelease
-  branch: master
+  branch: fix-fsnotify  # https://github.com/bitly/oauth2_proxy/issues/573
 - name: pdns
   uri: https://github.com/18F/pdns-release
   branch: master
-- name: prometheus
-  uri: https://github.com/18F/prometheus-boshrelease
-  branch: prom2-job
 - name: postfix
   uri: https://github.com/18F/postfix-boshrelease
   branch: master


### PR DESCRIPTION
* Use upstream prometheus
* Use temporary fix for oauth2 proxy