### PR TITLE
Revert experimental blobstore and bpm opsfiles.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -39,8 +39,6 @@ jobs:
       - bosh-deployment/uaa.yml
       - bosh-deployment/aws/cpi.yml
       - bosh-deployment/aws/iam-instance-profile.yml
-      - bosh-deployment/experimental/blobstore-https.yml
-      - bosh-deployment/experimental/bpm.yml
       - bosh-deployment/misc/powerdns.yml
       - bosh-config/operations/name.yml
       - bosh-config/operations/releases.yml


### PR DESCRIPTION
Now that upstream has moved blobstore tls and bpm into the base
manifest, we can drop the experimental opsfiles from our concourse
pipeline.