### PR TITLE
Use upstream release versions.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -12,12 +12,6 @@ jobs:
       trigger: true
     - get: bosh-stemcell
       trigger: true
-    - get: bosh-release
-      trigger: true
-    - get: uaa-release
-      trigger: true
-    - get: cpi-release
-      trigger: true
     - get: common-development
       trigger: true
     - get: terraform-yaml
@@ -31,14 +25,12 @@ jobs:
       manifest: bosh-deployment/bosh.yml
       stemcells:
       - bosh-stemcell/*.tgz
-      releases:
-      - bosh-release/*.tgz
-      - uaa-release/*.tgz
-      - cpi-release/*.tgz
       ops_files:
       - bosh-deployment/uaa.yml
       - bosh-deployment/aws/cpi.yml
       - bosh-deployment/aws/iam-instance-profile.yml
+      - bosh-deployment/misc/source-releases/bosh.yml
+      - bosh-deployment/misc/source-releases/uaa.yml
       - bosh-deployment/misc/powerdns.yml
       - bosh-config/operations/name.yml
       - bosh-config/operations/releases.yml
@@ -175,12 +167,6 @@ jobs:
       trigger: true
     - get: bosh-stemcell
       trigger: true
-    - get: bosh-release
-      trigger: true
-    - get: uaa-release
-      trigger: true
-    - get: cpi-release
-      trigger: true
     - get: common-staging
       trigger: true
     - get: terraform-yaml
@@ -292,13 +278,6 @@ jobs:
       trigger: true
     - get: bosh-stemcell
       passed: [deploy-staging-bosh]
-    - get: bosh-release
-      passed: [deploy-staging-bosh]
-      trigger: true
-    - get: uaa-release
-      passed: [deploy-staging-bosh]
-      trigger: true
-    - get: cpi-release
       passed: [deploy-staging-bosh]
       trigger: true
     - get: semver-tooling-version

--- a/operations/releases.yml
+++ b/operations/releases.yml
@@ -1,17 +1,8 @@
+# TODO: Delete after bosh-deployment updates to 266.3 or higher
 - type: replace
   path: /releases/name=bosh
   value:
     name: bosh
-    version: latest
-
-- type: replace
-  path: /releases/name=uaa
-  value:
-    name: uaa
-    version: latest
-
-- type: replace
-  path: /releases/name=bosh-aws-cpi
-  value:
-    name: bosh-aws-cpi
-    version: latest
+    version: "266.3.0"
+    url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=266.3.0
+    sha1: f2fc37fd5384ef741b5892b138eeebe25974c359


### PR DESCRIPTION
Now that bosh-deployment includes source release opsfiles, we can delegate release versions to upstream while still deploying the latest stemcell. More details in https://github.com/cloudfoundry/bosh-deployment/issues/180.