### PR TITLE
[WIP] Build elasticache broker release.

### DIFF
--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -58,3 +58,6 @@ releases:
 - name: domain-broker
   uri: https://github.com/18F/cf-domain-broker-alb-boshrelease
   branch: wip
+- name: elasticache-broker
+  uri: https://github.com/alphagov/paas-elasticache-broker-boshrelease
+  branch: master


### PR DESCRIPTION
Looks like I added this release to the pipeline while I was testing it out and then rolled it back. This is pointing to a fork at the moment, because upstream didn't check in a `releases` directory, which our release builder requires. We can ask upstream to check in releases, or move the fork to 18F, or allow our builder to handle releases without a `releases` directory. WDYT @LinuxBozo ?