### PR TITLE
Add bpm to legacy bosh deployments.

### DIFF
--- a/bosh-create-env-deployment.yml
+++ b/bosh-create-env-deployment.yml
@@ -8,6 +8,10 @@ releases:
 - name: bosh-aws-cpi
   url: (( grab $RELEASES_BOSH_AWS_CPI_URL ))
   sha1: (( grab $RELEASES_BOSH_AWS_CPI_SHA1 ))
+- name: bpm
+  version: 0.6.0
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bpm-release?v=0.6.0
+  sha1: 4f0f239abdc801d71de9063625aa56e3c42634b5
 
 resource_pools:
 - name: vms
@@ -59,6 +63,9 @@ instance_groups:
     - (( grab terraform_outputs.master_bosh_static_ip ))
 
   jobs:
+  - name: bpm
+    release: bpm
+    properties: {}
   - name: nats
     release: bosh
     properties:

--- a/bosh-deployment.yml
+++ b/bosh-deployment.yml
@@ -14,6 +14,10 @@ releases:
 - {name: cron, version: latest}
 - {name: ntp, version: latest}
 - {name: secureproxy, version: latest}
+- name: bpm
+  version: 0.6.0
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bpm-release?v=0.6.0
+  sha1: 4f0f239abdc801d71de9063625aa56e3c42634b5
 
 update:
   canaries: 1
@@ -128,6 +132,9 @@ instance_groups:
   instances: 1
   azs: [z1]
   jobs:
+  - name: bpm
+    release: bpm
+    properties: {}
   - name: nats
     release: bosh
     properties:


### PR DESCRIPTION
Bosh now requires the bpm release and job to run several of its jobs. We'll get rid of this change once we switch all bosh deployments to bosh-deployment, but we need this for now so that master and tooling bosh will continue to deploy.