### PR TITLE
Revert to upstream bosh release.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -33,7 +33,6 @@ jobs:
       - bosh-deployment/misc/source-releases/uaa.yml
       - bosh-deployment/misc/powerdns.yml
       - bosh-config/operations/name.yml
-      - bosh-config/operations/releases.yml
       - bosh-config/operations/s3-blobstore.yml
       - bosh-config/operations/external-db.yml
       - bosh-config/operations/uaa-clients.yml

--- a/operations/releases.yml
+++ b/operations/releases.yml
@@ -1,8 +1,0 @@
-# TODO: Delete after bosh-deployment updates to 266.3 or higher
-- type: replace
-  path: /releases/name=bosh
-  value:
-    name: bosh
-    version: "266.3.0"
-    url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=266.3.0
-    sha1: f2fc37fd5384ef741b5892b138eeebe25974c359


### PR DESCRIPTION
Now that upstream bosh-deployment has updated its bosh release version,
we can stop pinning versions here.