### PR TITLE
Drop nat ips from instance whitelist.

### DIFF
--- a/operations/cron.yml
+++ b/operations/cron.yml
@@ -21,7 +21,7 @@
           VPC_NAME: ((terraform_outputs.stack_description))
           BOSH_DIRECTOR: ((terraform_outputs.bosh_static_ip))
           GATEWAY_HOST: ((gateway_host))
-          INSTANCE_WHITELIST: ((terraform_outputs.nat_private_ip_az1)) ((terraform_outputs.nat_private_ip_az2)) ((terraform_outputs.master_bosh_static_ip)) ((terraform_outputs.bosh_static_ip))
+          INSTANCE_WHITELIST: ((terraform_outputs.master_bosh_static_ip)) ((terraform_outputs.bosh_static_ip))
         entries:
         - minute: '*'
           hour: '*'


### PR DESCRIPTION
Now that we're using managed nat gateways instead of nat instances, nat
services won't show up in our ec2 instance list and don't need to be
whitelisted.