### PR TITLE
Standardize ops files across deployments.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -389,24 +389,6 @@ jobs:
   - put: toolingbosh-deployment
     params:
       <<: *bosh-deployment
-      ops_files:
-      - bosh-deployment/uaa.yml
-      - bosh-deployment/credhub.yml
-      - bosh-deployment/aws/cpi.yml
-      - bosh-deployment/aws/iam-instance-profile.yml
-      - bosh-deployment/misc/source-releases/bosh.yml
-      - bosh-deployment/misc/source-releases/uaa.yml
-      - bosh-deployment/misc/powerdns.yml
-      - bosh-config/operations/name.yml
-      - bosh-config/operations/s3-blobstore.yml
-      - bosh-config/operations/external-db.yml
-      - bosh-config/operations/uaa-clients.yml
-      - bosh-config/operations/cloud-config.yml
-      - bosh-config/operations/update.yml
-      - bosh-config/operations/cron.yml
-      - bosh-config/operations/cpi.yml
-      - bosh-config/operations/ntp.yml
-      - bosh-config/operations/toolingbosh-tld.yml
       vars_files:
       - bosh-config/variables/tooling.yml
       - terraform-secrets/terraform.yml

--- a/operations/name.yml
+++ b/operations/name.yml
@@ -1,3 +1,7 @@
 - type: replace
   path: /name
   value: ((deployment_name))
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/dns/domain_name?
+  value: ((director_name))

--- a/operations/toolingbosh-tld.yml
+++ b/operations/toolingbosh-tld.yml
@@ -1,3 +1,0 @@
-- type: replace
-  path: /instance_groups/name=bosh/properties/dns/domain_name?
-  value: toolingbosh


### PR DESCRIPTION
Should result in no deployment diffs.