### PR TITLE
Drop kubernetes dns handler.

### DIFF
--- a/ci/update-runtime-config.sh
+++ b/ci/update-runtime-config.sh
@@ -23,5 +23,4 @@ bosh -n update-runtime-config \
 
 bosh -n update-runtime-config --name dns \
   bosh-deployment/runtime-configs/dns.yml \
-  --vars-file common/*.yml \
-  --ops-file bosh-config/operations/kubernetes-dns.yml
+  --vars-file common/*.yml

--- a/operations/kubernetes-dns.yml
+++ b/operations/kubernetes-dns.yml
@@ -1,8 +1,0 @@
-# TODO: Move to cf deployment after https://github.com/cloudfoundry/bosh-dns-aliases-release/pull/5 is resolved
-- type: replace
-  path: /addons/name=bosh-dns/jobs/name=bosh-dns/properties/handlers?/-
-  value:
-    domain: service.kubernetes.
-    source:
-      type: dns
-      recursors: ((kubernetes_recursors))


### PR DESCRIPTION
Now that https://github.com/cloudfoundry/bosh-dns-aliases-release/pull/5
has been released, we can configure kubernetes dns handlers on
individual deployments.