### PR TITLE
Fix push gateway dns in unknown vms checks.

### DIFF
--- a/operations/cron.yml
+++ b/operations/cron.yml
@@ -48,7 +48,7 @@
               # Hack: look up push gateway address in database if gateway is managed by the current director
               if [ -n "${GATEWAY_DEPLOYMENT}" ]; then
                 GATEWAY_HOST=$($PSQL -h ${PGHOST} -U ${PGUSERNAME} -d ${PGDBNAME} -t -c \
-                  "select ip from local_dns_records where deployment = '${GATEWAY_DEPLOYMENT}' and instance_group = 'prometheus'")
+                  "select ip from local_dns_records where deployment = '${GATEWAY_DEPLOYMENT}' and instance_group = 'prometheus' limit 1")
               fi
 
               # build JMESpath filter to exclude a list of instances based on their PrivateIpAddress

--- a/operations/cron.yml
+++ b/operations/cron.yml
@@ -21,6 +21,7 @@
           VPC_NAME: ((terraform_outputs.stack_description))
           BOSH_DIRECTOR: ((terraform_outputs.bosh_static_ip))
           GATEWAY_HOST: ((gateway_host))
+          GATEWAY_DEPLOYMENT: ((gateway_deployment))
           INSTANCE_WHITELIST: ((terraform_outputs.master_bosh_static_ip)) ((terraform_outputs.bosh_static_ip))
         entries:
         - minute: '*'
@@ -44,8 +45,11 @@
               AWSCLI=/var/vcap/packages/awslogs/bin/aws
               export LD_LIBRARY_PATH=/var/vcap/packages/awslogs/lib
 
-              # get the push gateway ip from toolingbosh
-              GATEWAY_IP=$(dig +short @${TOOLING_BOSH} ${GATEWAY_HOST})
+              # Hack: look up push gateway address in database if gateway is managed by the current director
+              if [ -n "${GATEWAY_DEPLOYMENT}" ]; then
+                GATEWAY_HOST=$($PSQL -h ${PGHOST} -U ${PGUSERNAME} -d ${PGDBNAME} -t -c \
+                  "select ip from local_dns_records where deployment = '${GATEWAY_DEPLOYMENT}' and instance_group = 'prometheus'")
+              fi
 
               # build JMESpath filter to exclude a list of instances based on their PrivateIpAddress
               query_filter() {
@@ -98,5 +102,5 @@
 
               done
 
-              curl -X PUT --data-binary "@${metrics}" "${GATEWAY_IP}:${PROMETHEUS_PUSH_GATEWAY_PORT:-9091}/metrics/job/bosh_unknown_instance/vpc_name/${VPC_NAME}"
+              curl -X PUT --data-binary "@${metrics}" "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/bosh_unknown_instance/vpc_name/${VPC_NAME}"
               rm "${metrics}"

--- a/variables/development.yml
+++ b/variables/development.yml
@@ -3,4 +3,5 @@ environment: development
 deployment_name: developmentbosh
 network: development-bosh
 instance_profile: development-bosh-profile
-gateway_host: 1.prometheus.staging-monitoring.prometheus-staging.toolingbosh
+gateway_host: prometheus-staging.service.cf.internal
+gateway_deployment: ""

--- a/variables/production.yml
+++ b/variables/production.yml
@@ -3,4 +3,5 @@ environment: production
 deployment_name: productionbosh
 network: production-bosh
 instance_profile: production-bosh-profile
-gateway_host: 0.prometheus.production-monitoring.prometheus-production.toolingbosh
+gateway_host: prometheus-production.service.cf.internal
+gateway_deployment: ""

--- a/variables/staging.yml
+++ b/variables/staging.yml
@@ -3,4 +3,5 @@ environment: staging
 deployment_name: stagingbosh
 network: staging-bosh
 instance_profile: staging-bosh-profile
-gateway_host: 1.prometheus.staging-monitoring.prometheus-staging.toolingbosh
+gateway_host: prometheus-staging.service.cf.internal
+gateway_deployment: ""

--- a/variables/tooling.yml
+++ b/variables/tooling.yml
@@ -3,4 +3,5 @@ environment: tooling
 deployment_name: toolingbosh
 network: bosh
 instance_profile: bosh-profile
-gateway_host: 0.prometheus.production-monitoring.prometheus-production.toolingbosh
+gateway_host: ""
+gateway_deployment: prometheus-production


### PR DESCRIPTION
* Use prometheus dns aliases for dev/stage/prod bosh
* Look up prometheus address via bosh db for tooling bosh