### PR TITLE
Set --no-align flag to trim whitespace from tuple.

### DIFF
--- a/operations/cron.yml
+++ b/operations/cron.yml
@@ -47,7 +47,7 @@
 
               # Hack: look up push gateway address in database if gateway is managed by the current director
               if [ -n "${GATEWAY_DEPLOYMENT}" ]; then
-                GATEWAY_HOST=$($PSQL -h ${PGHOST} -U ${PGUSERNAME} -d ${PGDBNAME} -t -c \
+                GATEWAY_HOST=$($PSQL -h ${PGHOST} -U ${PGUSERNAME} -d ${PGDBNAME} -tA -c \
                   "select ip from local_dns_records where deployment = '${GATEWAY_DEPLOYMENT}' and instance_group = 'prometheus' limit 1")
               fi
 


### PR DESCRIPTION
Fixes extra whitespace in psql query result.