### PR TITLE
Resize BOSH disks up to 20GB

### DIFF
--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -326,7 +326,7 @@
   path: /disk_types/-
   value:
     name: bosh
-    disk_size: 16_000
+    disk_size: 20_000
 - type: replace
   path: /disk_types/-
   value:


### PR DESCRIPTION
This is arbitrary. We resized these down 11 months ago from 30 GB to
16GB and then our alerting started complaining about 70% disk full. At
20GB, for the past 4 hours, it's been steady at 63% full on production.
Based on this limited research, I'm digging this middle ground of 20GB
instead of 16GB.