### PR TITLE
Use credhub bosh.io release instead of pre-compiled from upstream

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -42,6 +42,7 @@ jobs:
       - bosh-config/operations/cpi.yml
       - bosh-config/operations/dns.yml
       - bosh-config/operations/ntp.yml
+      - bosh-config/operations/source-release-credhub.yml
       vars_files:
       - bosh-config/variables/development.yml
       - terraform-secrets/terraform.yml

--- a/operations/source-release-credhub.yml
+++ b/operations/source-release-credhub.yml
@@ -1,0 +1,8 @@
+# this is here until we can switch to upstream pre-compiled for xenial stemcells
+- type: replace
+  path: /releases/name=credhub?
+  value:
+    name: "credhub"
+    version: "2.0.2"
+    url: "https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.0.2"
+    sha1: "490f7a1e521dd8fbb5ed1426d1148f6586e7e8c3"


### PR DESCRIPTION
This should solve any issues with pre-compiled credhub releases based on xenial now that upstream has switched to xenial as default stemcell.