### PR TITLE
Update disk size for logsearch-platform

### DIFF
--- a/cloud-config/development.yml
+++ b/cloud-config/development.yml
@@ -33,4 +33,4 @@
   value: 150_000
 - type: replace
   path: /disk_types/name=logsearch_es_platform_data/disk_size
-  value: 50_000
+  value: 75_000

--- a/cloud-config/main.yml
+++ b/cloud-config/main.yml
@@ -166,7 +166,7 @@
   path: /disk_types/-
   value:
     name: logsearch_es_platform_data
-    disk_size: 1_500_000
+    disk_size: 1_750_000
 - type: replace
   path: /disk_types/-
   value:


### PR DESCRIPTION
After fixing up clamav scan on access, we have lots of new data, and we never adjusted disk sizes. Rectify this.