### PR TITLE
Add in necessary params

### DIFF
--- a/ci/update-cloud-config-tooling-development.yml
+++ b/ci/update-cloud-config-tooling-development.yml
@@ -13,3 +13,10 @@ inputs:
 
 run:
   path: bosh-config/ci/update-cloud-config-tooling.sh
+
+params:
+  OPS_PATHS:
+  BOSH_CA_CERT:
+  BOSH_ENVIRONMENT:
+  BOSH_CLIENT:
+  BOSH_CLIENT_SECRET:

--- a/ci/update-cloud-config.yml
+++ b/ci/update-cloud-config.yml
@@ -12,3 +12,10 @@ inputs:
 
 run:
   path: bosh-config/ci/update-cloud-config.sh
+
+params:
+  OPS_PATHS:
+  BOSH_CA_CERT:
+  BOSH_ENVIRONMENT:
+  BOSH_CLIENT:
+  BOSH_CLIENT_SECRET:

--- a/ci/update-runtime-config.yml
+++ b/ci/update-runtime-config.yml
@@ -22,3 +22,9 @@ inputs:
 
 run:
   path: bosh-config/ci/update-runtime-config.sh
+
+params:
+  BOSH_CA_CERT:
+  BOSH_ENVIRONMENT:
+  BOSH_CLIENT:
+  BOSH_CLIENT_SECRET:


### PR DESCRIPTION
This behavior has been deprecated since 4.1.0 and will eventually cause an error in later Concourse versions.
https://concourse-ci.org/download.html#v410