### PR TITLE
Double the disk space for BOSH VMs

### DIFF
--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -326,7 +326,7 @@
   path: /disk_types/-
   value:
     name: bosh
-    disk_size: 20_000
+    disk_size: 40_000
 - type: replace
   path: /disk_types/-
   value:


### PR DESCRIPTION
We ~~argue~~ bikeshed about this on the reg here, https://gsa-tts.slack.com/archives/C0ENP71UG/p1537372483000100

**What do y'all think?** Is 40GB enough? That doubles the diskspace and the SWAP. Should we keep SWAP at 10GB instead of the default? 50% of whatever the diskspace is?