### PR TITLE
Use our own cron release until upstream does release with bugfix

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -668,9 +668,14 @@ resources:
     server_side_encryption: AES256
 
 - name: cron-release
-  type: bosh-io-release
+  # type: bosh-io-release
+  # source:
+  #   repository: cloudfoundry-community/cron-boshrelease
+  # Use our own version until community release is updated
+  type: s3-iam
   source:
-    repository: cloudfoundry-community/cron-boshrelease
+    regexp: cron-(.*).tgz
+    <<: *s3-release-params
 
 - name: ntp-release
   type: bosh-io-release

--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -31,6 +31,9 @@ releases:
 - name: admin-ui
   uri: https://github.com/jmcarp/admin-ui-boshrelease
   branch: deploy
+- name: cron
+  uri: https://github.com/cloudfoundry-community/cron-boshrelease
+  branch: master
 - name: kubernetes
   uri: https://github.com/18F/kubernetes-release
   branch: master
@@ -63,4 +66,4 @@ releases:
   branch: master
 - name: falco
   uri: https://github.com/cloudfoundry-community/falco-boshrelease
-  branch: master
+  branch: gardener


### PR DESCRIPTION
Bugfix needed: https://github.com/cloudfoundry-community/cron-boshrelease/pull/8

Last known upstream release details:
```
cron BOSH Release v1.1.3
@starkandwayne-bot starkandwayne-bot released this on Jan 27, 2017 
5 commits to master since this release
```