### PR TITLE
Add tag_filter to lock-in Trusty

### DIFF
--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -12,6 +12,7 @@ releases:
 - name: awslogs
   uri: https://github.com/18F/cg-awslogs-boshrelease
   branch: master
+  tag_filter: trusty-*
 - name: clamav
   uri: https://github.com/18F/cg-clamav-boshrelease
   branch: master


### PR DESCRIPTION
This will pickup any tags that start `trusty-` for `awslogs`. This is the old Trusty compatible version of `awslogs-boshrelease`. The new version will be named `awslogs-xenial` and will be added in a PR later on. To ensure this tag exists, checkout [the `cg-awslogs-boshrelease` repo](https://github.com/18F/cg-awslogs-boshrelease) under [tags](https://github.com/18F/cg-awslogs-boshrelease/tags).