### PR TITLE
Rename the base branch for Trusty

### DIFF
--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -11,7 +11,7 @@ releases:
   branch: master
 - name: awslogs
   uri: https://github.com/18F/cg-awslogs-boshrelease
-  branch: master
+  branch: master-trusty
   tag_filter: trusty-*
 - name: clamav
   uri: https://github.com/18F/cg-clamav-boshrelease


### PR DESCRIPTION
This is so we can continue forking our code for both Xenial and Trusty
with minimal confusion. The docs explaining this exist in the
`cg-awslogs-boshrelease` [repository](https://github.com/18F/cg-awslogs-boshrelease).