### PR TITLE
[wip] Add awslogs-xenial boshrelease

### DIFF
--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -13,6 +13,9 @@ releases:
   uri: https://github.com/18F/cg-awslogs-boshrelease
   branch: master-trusty
   tag_filter: trusty-*
+- name: awslogs-xenial
+  uri: https://github.com/18F/cg-awslogs-boshrelease
+  branch: upgrade-to-xenial
 - name: clamav
   uri: https://github.com/18F/cg-clamav-boshrelease
   branch: master


### PR DESCRIPTION
Currently a _work in progress_, eventually this boshrelease will be working off of `master` and not some arbitrary branch e.g. `upgrade-to-xenial`.