### PR TITLE
Resize disks up to 3.5T for logsearch-platform

### DIFF
--- a/cloud-config/main.yml
+++ b/cloud-config/main.yml
@@ -166,7 +166,7 @@
   path: /disk_types/-
   value:
     name: logsearch_es_platform_data
-    disk_size: 2_750_000
+    disk_size: 3_500_000
 - type: replace
   path: /disk_types/-
   value:


### PR DESCRIPTION
**do not merge this yet**
This should alleviate the disk issues we've seen in production about disks being at 70% for logsearch-platform in production. Pairing with @jontours on this.