### PR TITLE
Rename awslogs to &-trusty everywhere

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -93,8 +93,11 @@ jobs:
       trigger: true
     - get: cg-s3-tripwire-release
       trigger: true
-    - get: cg-s3-awslogs-release
-      resource: cg-s3-awslogs-release-development
+    - get: cg-s3-awslogs-trusty-release
+      resource: cg-s3-awslogs-trusty-release-development
+      trigger: true
+    - get: cg-s3-awslogs-xenial-release
+      resource: cg-s3-awslogs-xenial-release-development
       trigger: true
     - get: cg-s3-nessus-agent-release
       trigger: true
@@ -123,7 +126,8 @@ jobs:
       - {name: certificate}
       - {name: cg-s3-fisma-release, path: releases/fisma}
       - {name: cg-s3-tripwire-release, path: releases/tripwire}
-      - {name: cg-s3-awslogs-release, path: releases/awslogs-trusty}
+      - {name: cg-s3-awslogs-trusty-release, path: releases/awslogs-trusty}
+      - {name: cg-s3-awslogs-xenial-release, path: releases/awslogs-xenial}
       - {name: cg-s3-nessus-agent-release, path: releases/nessus-agent}
       - {name: cg-s3-clamav-release, path: releases/clamav}
       - {name: cg-s3-snort-release, path: releases/snort}
@@ -226,7 +230,7 @@ jobs:
       trigger: true
     - get: cg-s3-tripwire-release
       trigger: true
-    - get: cg-s3-awslogs-release
+    - get: cg-s3-awslogs-trusty-release
       trigger: true
     - get: cg-s3-nessus-agent-release
       trigger: true
@@ -338,7 +342,7 @@ jobs:
       trigger: true
     - get: cg-s3-tripwire-release
       trigger: true
-    - get: cg-s3-awslogs-release
+    - get: cg-s3-awslogs-trusty-release
       trigger: true
     - get: cg-s3-nessus-agent-release
       trigger: true
@@ -445,7 +449,7 @@ jobs:
       trigger: true
     - get: cg-s3-tripwire-release
       trigger: true
-    - get: cg-s3-awslogs-release
+    - get: cg-s3-awslogs-trusty-release
       trigger: true
     - get: cg-s3-nessus-agent-release
       trigger: true
@@ -470,7 +474,7 @@ jobs:
       - {name: certificate}
       - {name: cg-s3-fisma-release, path: releases/fisma}
       - {name: cg-s3-tripwire-release, path: releases/tripwire}
-      - {name: cg-s3-awslogs-release, path: releases/awslogs-trusty}
+      - {name: cg-s3-awslogs-trusty-release, path: releases/awslogs-trusty}
       - {name: cg-s3-nessus-agent-release, path: releases/nessus-agent}
       - {name: cg-s3-clamav-release, path: releases/clamav}
       - {name: cg-s3-snort-release, path: releases/snort}
@@ -512,7 +516,7 @@ jobs:
       trigger: true
     - get: cg-s3-tripwire-release
       trigger: true
-    - get: cg-s3-awslogs-release
+    - get: cg-s3-awslogs-trusty-release
       trigger: true
     - get: cg-s3-nessus-agent-release
       trigger: true
@@ -537,7 +541,7 @@ jobs:
       - {name: certificate}
       - {name: cg-s3-fisma-release, path: releases/fisma}
       - {name: cg-s3-tripwire-release, path: releases/tripwire}
-      - {name: cg-s3-awslogs-release, path: releases/awslogs-trusty}
+      - {name: cg-s3-awslogs-trusty-release, path: releases/awslogs-trusty}
       - {name: cg-s3-nessus-agent-release, path: releases/nessus-agent}
       - {name: cg-s3-clamav-release, path: releases/clamav}
       - {name: cg-s3-snort-release, path: releases/snort}
@@ -772,15 +776,25 @@ resources:
     regexp: tripwire-(.*).tgz
     <<: *s3-release-params
 
-- &awslogs-release
-  name: cg-s3-awslogs-release
+- &awslogs-trusty-release
+  name: cg-s3-awslogs-trusty-release
   type: s3-iam
   source:
-    regexp: awslogs-trusty(.*).tgz
+    regexp: awslogs-trusty-(.*).tgz
     <<: *s3-release-params
 
-- <<: *awslogs-release
-  name: cg-s3-awslogs-release-development
+- <<: *awslogs-trusty-release
+  name: cg-s3-awslogs-trusty-release-development
+
+- &awslogs-xenial-release
+  name: cg-s3-awslogs-xenial-release
+  type: s3-iam
+  source:
+    regexp: awslogs-xenial-(.*).tgz
+    <<: *s3-release-params
+
+- <<: *awslogs-xenial-release
+  name: cg-s3-awslogs-xenial-release-development
 
 - name: cg-s3-nessus-agent-release
   type: s3-iam

--- a/ci/update-runtime-config.yml
+++ b/ci/update-runtime-config.yml
@@ -13,7 +13,7 @@ inputs:
 - {name: common}
 - {name: cg-s3-fisma-release, path: releases/fisma}
 - {name: cg-s3-tripwire-release, path: releases/tripwire}
-- {name: cg-s3-awslogs-release, path: releases/awslogs}
+- {name: cg-s3-awslogs-trusty-release, path: releases/awslogs-trusty}
 - {name: cg-s3-nessus-agent-release, path: releases/nessus-agent}
 - {name: cg-s3-clamav-release, path: releases/clamav}
 - {name: cg-s3-snort-release, path: releases/snort}

--- a/operations/cron.yml
+++ b/operations/cron.yml
@@ -42,8 +42,8 @@
               # apps from other packages on this host we need
               PSQL=/var/vcap/packages/postgres-9.4/bin/psql
 
-              AWSCLI=/var/vcap/packages/awslogs/bin/aws
-              export LD_LIBRARY_PATH=/var/vcap/packages/awslogs/lib
+              AWSCLI=/var/vcap/packages/awslogs-trusty/bin/aws
+              export LD_LIBRARY_PATH=/var/vcap/packages/awslogs-trusty/lib
 
               # Hack: look up push gateway address in database if gateway is managed by the current director
               if [ -n "${GATEWAY_DEPLOYMENT}" ]; then

--- a/runtime-config/runtime.yml
+++ b/runtime-config/runtime.yml
@@ -3,7 +3,7 @@ releases:
 - {name: tripwire, version: ((release_tripwire))}
 - {name: clamav, version: ((release_clamav))}
 - {name: snort, version: ((release_snort))}
-- {name: awslogs, version: ((release_awslogs))}
+- {name: awslogs-trusty, version: ((release_awslogs-trusty))}
 - {name: nessus-agent, version: ((release_nessus_agent))}
 - {name: node-exporter, version: ((release_node_exporter))}
 - {name: syslog, version: ((release_syslog))}
@@ -15,7 +15,7 @@ addons:
   - {name: tripwire, release: tripwire}
   - {name: clamav, release: clamav}
   - {name: snort, release: snort}
-  - {name: awslogs, release: awslogs}
+  - {name: awslogs-trusty, release: awslogs-trusty}
   - {name: nessus-agent, release: nessus-agent}
   - {name: node_exporter, release: node-exporter}
   - {name: syslog_forwarder, release: syslog}
@@ -23,7 +23,7 @@ addons:
     tripwire:
       localpass: ((tripwire_localpass))
       sitepass: ((tripwire_sitepass))
-    awslogs:
+    awslogs-trusty:
       region: ((terraform_outputs.vpc_region))
     nessus-agent:
       key: ((nessus_agent_key))


### PR DESCRIPTION
This patch also adds awslogs-xenial to the development pipeline jobs as
well.


**I have done the following**

- Flown the pipeline here with these changes
- Allowed the upload of two different awslogs to the development BOSH
- Renamed the awslogs resource to awslogs-trusty resource to avoid any weird naming issues in Concourse
- Created an awslogs-xenial resource that is being used for development BOSH