### PR TITLE
Bump CH version and fix ops file for external-db

### DIFF
--- a/operations/external-db.yml
+++ b/operations/external-db.yml
@@ -2,6 +2,9 @@
   path: /instance_groups/name=bosh/jobs/name=postgres-9.4?
 
 - type: remove
+  path: /instance_groups/name=bosh/jobs/name=postgres-10?
+
+- type: remove
   path: /instance_groups/name=bosh/properties/postgres
 
 - type: replace

--- a/operations/external-db.yml
+++ b/operations/external-db.yml
@@ -1,5 +1,5 @@
 - type: remove
-  path: /instance_groups/name=bosh/jobs/name=postgres-9.4
+  path: /instance_groups/name=bosh/jobs/name=postgres-9.4?
 
 - type: remove
   path: /instance_groups/name=bosh/properties/postgres

--- a/operations/source-release-credhub.yml
+++ b/operations/source-release-credhub.yml
@@ -3,6 +3,6 @@
   path: /releases/name=credhub?
   value:
     name: "credhub"
-    version: "2.1.1"
-    url: "https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.1.1"
-    sha1: "dd0b607d855a8d23e6fd52b990573570e68bbbf6"
+    version: "2.1.2"
+    url: "https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.1.2"
+    sha1: "754a24dbffe8bc5efce7e698d935b5f4df541f38"


### PR DESCRIPTION
Abides by `mode` parameter to limit cred generation iff that cred exists.  @rogeruiz let's wait to merge until CF creds are rotated for this round.