### PR TITLE
remove deprecated properties block from addon, add to jobs

### DIFF
--- a/runtime-config/runtime.yml
+++ b/runtime-config/runtime.yml
@@ -11,26 +11,33 @@ releases:
 addons:
 - name: hardening
   jobs:
-  - {name: harden, release: fisma}
-  - {name: tripwire, release: tripwire}
-  - {name: clamav, release: clamav}
-  - {name: snort, release: snort}
-  - {name: awslogs-xenial, release: awslogs-xenial}
-  - {name: nessus-agent, release: nessus-agent}
-  - {name: node_exporter, release: node-exporter}
-  - {name: syslog_forwarder, release: syslog}
-  properties:
-    tripwire:
+  - name: harden
+    release: fisma
+  - name: tripwire
+    release: tripwire
+    properties:
       localpass: ((tripwire_localpass))
       sitepass: ((tripwire_sitepass))
-    awslogs-xenial:
+  - name: clamav
+    release: clamav
+  - name: snort
+    release: snort
+  - name: awslogs-xenial
+    release: awslogs-xenial
+    properties:
       region: ((terraform_outputs.vpc_region))
-    nessus-agent:
+  - name: nessus-agent
+    release: nessus-agent
+    properties:
       key: ((nessus_agent_key))
       group: ((nessus_agent_group))
       server: ((terraform_outputs.nessus_static_ip))
       port: 8834
-    syslog:
+  - name: node_exporter
+    release: node-exporter
+  - name: syslog_forwarder
+    release: syslog
+    properties:
       address: ((terraform_outputs.platform_syslog_elb_dns_name))
       port: 5514
 


### PR DESCRIPTION
this is due to https://www.pivotaltracker.com/story/show/167907044/comments/205808093, and should fix builds failing with this error:
`Error: Addon 'hardening' specifies 'properties' which is not supported. 'properties' are only allowed in the 'jobs' array`