### PR TITLE
set s3 config on bosh agents

### DIFF
--- a/operations/s3-blobstore.yml
+++ b/operations/s3-blobstore.yml
@@ -16,3 +16,12 @@
 
 - type: remove
   path: /instance_groups/name=bosh/properties/agent/env/bosh/blobstores
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/agent/env/bosh/blobstores?/-
+  value:
+    provider: s3
+    options:
+      bucket_name: ((terraform_outputs.bosh_blobstore_bucket))
+      region: ((terraform_outputs.vpc_region))
+      credentials_source: env_or_profile


### PR DESCRIPTION
Following along the instructions in cloudfoundry/bosh-deployment#254
We need to set the blobstore config on the agent, rather than just removing it due to bosh API change.