### PR TITLE
set access_key_id and secret_access_key as an attempted workaround

### DIFF
--- a/operations/s3-blobstore.yml
+++ b/operations/s3-blobstore.yml
@@ -25,3 +25,6 @@
       bucket_name: ((terraform_outputs.bosh_blobstore_bucket))
       region: ((terraform_outputs.vpc_region))
       credentials_source: env_or_profile
+      access_key_id: null
+      secret_access_key: null
+


### PR DESCRIPTION
[this commit](https://github.com/cloudfoundry/bosh/commit/b2383dfc2f147d8cafe61323ea8d9157979ba881#diff-99e4eca64232c4ddfa30b3b73740f315) is causing our config to fail validation. This is an attempt at a workaround while we work with the upstream to patch it.

