### PR TITLE
use source release for credhub in dev

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -31,6 +31,7 @@ jobs:
       - bosh-deployment/aws/cpi.yml
       - bosh-deployment/aws/iam-instance-profile.yml
       - bosh-deployment/misc/source-releases/bosh.yml
+      - bosh-deployment/misc/source-releases/credhub.yml
       - bosh-deployment/misc/source-releases/uaa.yml
       - bosh-config/operations/name.yml
       - bosh-config/operations/s3-blobstore.yml


### PR DESCRIPTION
This will hopefully allow us to deploy credhub across a wider variety of stemcells, getting us unstuck on pinning other versions periodically.