### PR TITLE
supply our own opsfile for credhub

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,4 +1,9 @@
 ---
+meta:
+  s3-release-params: &s3-release-params
+    bucket: ((s3-bosh-releases-bucket))
+    region_name: ((aws-region))
+    private: true
 jobs:
 - name: deploy-development-bosh
   serial: true
@@ -31,7 +36,6 @@ jobs:
       - bosh-deployment/aws/cpi.yml
       - bosh-deployment/aws/iam-instance-profile.yml
       - bosh-deployment/misc/source-releases/bosh.yml
-      - bosh-deployment/misc/source-releases/credhub.yml
       - bosh-deployment/misc/source-releases/uaa.yml
       - bosh-config/operations/name.yml
       - bosh-config/operations/s3-blobstore.yml
@@ -44,6 +48,7 @@ jobs:
       - bosh-config/operations/dns.yml
       - bosh-config/operations/ntp.yml
       - bosh-config/operations/remove-old-blobstore-ca.yml
+      - bosh-config/operations/credhub-source.yml
       vars_files:
       - bosh-config/variables/development.yml
       - terraform-secrets/terraform.yml
@@ -409,6 +414,7 @@ jobs:
       - bosh-deployment/aws/iam-instance-profile.yml
       - bosh-deployment/misc/source-releases/bosh.yml
       - bosh-deployment/misc/source-releases/uaa.yml
+      - bosh-deployment/misc/source-releases/credhub.yml
       - bosh-config/operations/name.yml
       - bosh-config/operations/s3-blobstore.yml
       - bosh-config/operations/external-db.yml
@@ -420,6 +426,7 @@ jobs:
       - bosh-config/operations/dns.yml
       - bosh-config/operations/ntp.yml
       - bosh-config/operations/add-new-saml-key.yml
+      - bosh-config/operations/credhub-source.yml
   - task: update-cloud-config
     file: bosh-config/ci/update-cloud-config-tooling.yml
     params:
@@ -894,7 +901,3 @@ resource_types:
   source:
     repository: governmentpaas/semver-resource
 
-s3-release-params: &s3-release-params
-  bucket: ((s3-bosh-releases-bucket))
-  region_name: ((aws-region))
-  private: true

--- a/operations/credhub-source.yml
+++ b/operations/credhub-source.yml
@@ -1,0 +1,8 @@
+- path: /releases/name=credhub?
+  release: credhub
+  type: replace
+  value:
+    name: credhub
+    sha1: 9647fff0fcb249e71ba2290849b4cdbbf7550165
+    url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.5.7
+    version: 2.5.7


### PR DESCRIPTION
using the opsfile from bosh-deployment still leaves us stuck with bosh and credhub versions pinned together. this should separate them