### PR TITLE
bigger logsearch disks

### DIFF
--- a/cloud-config/staging.yml
+++ b/cloud-config/staging.yml
@@ -18,4 +18,4 @@
 
 - type: replace
   path: /disk_types/name=logsearch_es_data/disk_size
-  value: 300_000
+  value: 600_000


### PR DESCRIPTION
Logsearch in staging is failing due to overfull disks. This doubles the disk size, which should fix it. 