### PR TITLE
Revert "move runtime config updates to deployment step."

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -559,6 +559,15 @@ jobs:
         BOSH_ENVIRONMENT: ((masterbosh-target))
   - put: semver-master-version
     params: {bump: patch}
+  - task: update-runtime-config
+    file: bosh-config/ci/update-runtime-config.yml
+    input_mapping:
+      common: common-master
+    params:
+      BOSH_CA_CERT: ((common_ca_cert_store))
+      BOSH_ENVIRONMENT: ((masterbosh-target))
+      BOSH_CLIENT: admin
+      BOSH_CLIENT_SECRET: ((master_bosh_admin_password))
 
 - name: deploy-master-bosh
   serial: true
@@ -587,15 +596,6 @@ jobs:
     file: bosh-config/ci/update-cloud-config.yml
     params:
       OPS_PATHS: "bosh-config/cloud-config/master.yml"
-      BOSH_CA_CERT: ((common_ca_cert_store))
-      BOSH_ENVIRONMENT: ((masterbosh-target))
-      BOSH_CLIENT: admin
-      BOSH_CLIENT_SECRET: ((master_bosh_admin_password))
-  - task: update-runtime-config
-    file: bosh-config/ci/update-runtime-config.yml
-    input_mapping:
-      common: common-master
-    params:
       BOSH_CA_CERT: ((common_ca_cert_store))
       BOSH_ENVIRONMENT: ((masterbosh-target))
       BOSH_CLIENT: admin


### PR DESCRIPTION
This reverts commit 3ea0c529d487ad52e94fe2e8e6ebbbc2fd058069.

I was wrong on the order for many reasons.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>