### PR TITLE
bigger disks for logsearch-platform in dev

### DIFF
--- a/cloud-config/development.yml
+++ b/cloud-config/development.yml
@@ -33,4 +33,4 @@
   value: 150_000
 - type: replace
   path: /disk_types/name=logsearch_es_platform_data/disk_size
-  value: 100_000
+  value: 200_000


### PR DESCRIPTION
logsearch-platform-development isn't deploying because it can't allocate all its shards because it lacks disk space. This should fix it. 

# Security Considerations
none - this is a dev scaling operation