### PR TITLE
WIP: staging bosh now uses credhub.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -174,8 +174,6 @@ jobs:
       trigger: true
     - get: bosh-stemcell-xenial
       trigger: true
-    - get: common-staging
-      trigger: true
     - get: terraform-yaml
       resource: terraform-yaml-staging
     - get: semver-tooling-version
@@ -189,7 +187,6 @@ jobs:
       - bosh-config/variables/staging.yml
       - terraform-secrets/terraform.yml
       - terraform-yaml/state.yml
-      - common-staging/staging-bosh.yml
   - task: update-cloud-config
     file: bosh-config/ci/update-cloud-config.yml
     params:
@@ -228,8 +225,6 @@ jobs:
     - get: bosh-config
     - get: terraform-yaml
       resource: terraform-yaml-staging
-    - get: common-staging
-      trigger: true
     - get: cg-s3-fisma-release
       trigger: true
     - get: cg-s3-tripwire-release
@@ -262,8 +257,6 @@ jobs:
         BOSH_ENVIRONMENT: ((stagingbosh-target))
   - task: update-runtime-config
     file: bosh-config/ci/update-runtime-config.yml
-    input_mapping:
-      common: common-staging
     params:
       BOSH_CA_CERT: ((common_ca_cert_store))
       BOSH_ENVIRONMENT: ((stagingbosh-target))
@@ -657,13 +650,6 @@ resources:
     bucket: ((secrets-bucket))
     region_name: ((aws-region))
     versioned_file: development-bosh.yml
-
-- name: common-staging
-  type: s3-iam
-  source:
-    bucket: ((secrets-bucket))
-    region_name: ((aws-region))
-    versioned_file: staging-bosh.yml
 
 - name: common-production
   type: s3-iam

--- a/ci/update-runtime-config.sh
+++ b/ci/update-runtime-config.sh
@@ -22,10 +22,8 @@ fi
 bosh -n update-runtime-config \
   bosh-config/runtime-config/runtime.yml \
   --vars-env runtime \
-  --vars-file terraform-yaml/state.yml \
-  --vars-file common/*.yml
+  --vars-file terraform-yaml/state.yml
 
 bosh -n update-runtime-config --name dns \
   bosh-deployment/runtime-configs/dns.yml \
-  --vars-file common/*.yml \
   --ops-file bosh-config/operations/dns-aliases.yml


### PR DESCRIPTION
Removed all the references to `common-staging` and unmapped the common staging for the task file.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>