### PR TITLE
correct domain broker branch

### DIFF
--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -60,7 +60,7 @@ releases:
   branch: master
 - name: domain-broker
   uri: https://github.com/18F/cf-domain-broker-alb-boshrelease
-  branch: wip
+  branch: master
 - name: elasticache-broker
   uri: https://github.com/alphagov/paas-elasticache-broker-boshrelease
   branch: master


### PR DESCRIPTION
the branches `wip` and `master` on 18F/cf-domain-broker-alb-boshrelease are identical, so we should build master rather than wip

# Security Considerations
None