### PR TITLE
double logsearch-platform disk size in dev

### DIFF
--- a/cloud-config/development.yml
+++ b/cloud-config/development.yml
@@ -33,4 +33,4 @@
   value: 150_000
 - type: replace
   path: /disk_types/name=logsearch_es_platform_data/disk_size
-  value: 200_000
+  value: 400_000


### PR DESCRIPTION
dev is failing to deploy because its disks are too full to reallocate shards

# security considerations
None