### PR TITLE
tooling: map doomsday lb group to vm extension.

### DIFF
--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -293,14 +293,14 @@
     name: staging-doomsday-lb
     cloud_properties:
       lb_target_groups:
-      - ((terraform_outputs.staging_monitoring_lb_target_group))
+      - ((terraform_outputs.staging_doomsday_lb_target_group))
 - type: replace
   path: /vm_extensions/-
   value:
     name: production-doomsday-lb
     cloud_properties:
       lb_target_groups:
-      - ((terraform_outputs.production_monitoring_lb_target_group))
+      - ((terraform_outputs.production_doomsday_lb_target_group))
 - type: replace
   path: /vm_extensions/-
   value:


### PR DESCRIPTION
This fixes the LB group for doomsday. Manually tested and it works as intended.

## Security Considerations

None.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>