### PR TITLE
workaround for ignoring IP addresses dynamically assigned by AWS

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -50,6 +50,7 @@ jobs:
       - bosh-config/operations/add-new-saml-key.yml
       - bosh-config/operations/remove-old-blobstore-ca.yml
       - bosh-config/operations/credhub-source.yml
+      - bosh-config/operations/reserved-ips.yml
       vars_files:
       - bosh-config/variables/development.yml
       - terraform-secrets/terraform.yml

--- a/operations/reserved-ips.yml
+++ b/operations/reserved-ips.yml
@@ -2,4 +2,4 @@
 # that AWS has claimed in the services network (usually ELBs/ALBs)
 - type: replace
   path: /networks/services/subnets/az=z1/reserved-
-  value: ((services_reserved_ips))
+  value: ((services_z1_reserved_ips))

--- a/operations/reserved-ips.yml
+++ b/operations/reserved-ips.yml
@@ -1,5 +1,6 @@
 # this dumb workaround allows us to manually plug in IP addresses
 # that AWS has claimed in the services network (usually ELBs/ALBs)
+# set this variable in Credhub, as a list of IP addresses manually collected from AWS
 - type: replace
   path: /networks/services/subnets/az=z1/reserved-
   value: ((services_z1_reserved_ips))

--- a/operations/reserved-ips.yml
+++ b/operations/reserved-ips.yml
@@ -2,4 +2,4 @@
 # that AWS has claimed in the services network (usually ELBs/ALBs)
 - type: replace
   path: /networks/services/subnets/az=z1/reserved-
-  value: ((services_reserved_ips)
+  value: ((services_reserved_ips))

--- a/operations/reserved-ips.yml
+++ b/operations/reserved-ips.yml
@@ -1,0 +1,5 @@
+# this dumb workaround allows us to manually plug in IP addresses
+# that AWS has claimed in the services network (usually ELBs/ALBs)
+- type: replace
+  path: /networks/services/subnets/az=z1/reserved-
+  value: ((services_reserved_ips)


### PR DESCRIPTION
We're not putting aws-managed services (e.g. ELBs) into different subnets from bosh, so sometimes AWS assigns them an IP address that gets in the way. This lets us tell bosh about these addresses (in the services network, at least) so we can avoid errors like `Error: Unknown CPI error 'Unknown' with message 'Address  <ip address> is in use.' in 'create_vm' CPI method `

# Security Considerations
None