### PR TITLE
added doomsday-clients.

### DIFF
--- a/operations/uaa-clients.yml
+++ b/operations/uaa-clients.yml
@@ -17,6 +17,15 @@
     secret: "((bosh_exporter_client_secret))"
 
 - type: replace
+  path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/clients/doomsday-readonly?
+  value:
+    override: true
+    authorized-grant-types: client_credentials,refresh_token
+    authorities: credhub.write,credhub.read
+    scope: uaa.none
+    secret: "((doomsday-readonly-secret))"
+
+- type: replace
   path: /variables/-
   value:
     name: bosh_ci_client_secret
@@ -26,4 +35,10 @@
   path: /variables/-
   value:
     name: bosh_exporter_client_secret
+    type: password
+
+- type: replace
+  path: /variables/-
+  value:
+    name: doomsday-readonly-secret
     type: password


### PR DESCRIPTION
## Changes proposed in this pull request:
- add the clients via deployment manifest instead of manually.

## security considerations

Just makes it more repeatable. There is no way to limit the scope to just `credhub.read`, that currently fails, so `credhub.write` must also be granted.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>