### PR TITLE
get on source releases.

### DIFF
--- a/bosh-create-env.sh
+++ b/bosh-create-env.sh
@@ -14,13 +14,14 @@ bosh create-env \
   --ops-file bosh-deployment/aws/cli-iam-instance-profile.yml \
   --ops-file bosh-deployment/misc/powerdns.yml \
   --ops-file bosh-deployment/misc/source-releases/bosh.yml \
+  --ops-file bosh-deployment/misc/source-releases/credhub.yml \
+  --ops-file bosh-deployment/misc/source-releases/uaa.yml \
   --ops-file bosh-deployment/jumpbox-user.yml \
   --ops-file bosh-deployment/uaa.yml \
   --ops-file bosh-deployment/credhub.yml \
   --ops-file bosh-config/operations/cpi.yml \
   --ops-file bosh-config/operations/encryption.yml \
   --ops-file bosh-config/operations/add-postgres-9.yml \
-  --ops-file bosh-config/operations/credhub-source.yml \
   --vars-file bosh-config/variables/master.yml \
   --vars-file terraform-yaml/state.yml \
   --vars-file terraform-secrets/terraform.yml \

--- a/operations/credhub-source.yml
+++ b/operations/credhub-source.yml
@@ -1,8 +1,0 @@
-- path: /releases/name=credhub?
-  release: credhub
-  type: replace
-  value:
-    name: credhub
-    sha1: 9647fff0fcb249e71ba2290849b4cdbbf7550165
-    url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.5.7
-    version: 2.5.7


### PR DESCRIPTION
## Changes proposed in this pull request:
- get rid of credhub lock.
- use the formal ops files for source releases.

## security considerations

Just updates.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>