### PR TITLE
new instances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 ## cloud.gov bosh configuration
 
 This repo contains the Concourse pipeline and BOSH manifests for deploying BOSH via [bosh-deployment](https://github.com/cloudfoundry/bosh-deployment).
+
+## Updating the instance types
+
+Every once in awhile AWS adds new or deprecates old instance types, which means the cloud config will need to be updated. The easiest way to do this is by running the `generate-instance-config.sh` script and copying the output to `.vm_types` section of the [`base.yml`](./cloud-config/base.yml) file.

--- a/cloud-config/base.yml
+++ b/cloud-config/base.yml
@@ -19,495 +19,495 @@ vm_types:
 - name: errand_large
   cloud_properties:
     instance_type: m4.large
-- name: m5.xlarge
-  cloud_properties:
-    instance_type: m5.xlarge
-- name: r5d.4xlarge
-  cloud_properties:
-    instance_type: r5d.4xlarge
-- name: m5ad.4xlarge
-  cloud_properties:
-    instance_type: m5ad.4xlarge
-- name: m4.16xlarge
-  cloud_properties:
-    instance_type: m4.16xlarge
-- name: r3.4xlarge
-  cloud_properties:
-    instance_type: r3.4xlarge
-- name: m5d.large
-  cloud_properties:
-    instance_type: m5d.large
-- name: r5.4xlarge
-  cloud_properties:
-    instance_type: r5.4xlarge
-- name: c5.12xlarge
-  cloud_properties:
-    instance_type: c5.12xlarge
-- name: c5n.4xlarge
-  cloud_properties:
-    instance_type: c5n.4xlarge
-- name: r5a.4xlarge
-  cloud_properties:
-    instance_type: r5a.4xlarge
-- name: t3.xlarge
-  cloud_properties:
-    instance_type: t3.xlarge
-- name: r5a.12xlarge
-  cloud_properties:
-    instance_type: r5a.12xlarge
-- name: r5a.large
-  cloud_properties:
-    instance_type: r5a.large
-- name: m5a.16xlarge
-  cloud_properties:
-    instance_type: m5a.16xlarge
-- name: r3.8xlarge
-  cloud_properties:
-    instance_type: r3.8xlarge
-- name: t2.micro
-  cloud_properties:
-    instance_type: t2.micro
-- name: t3.large
-  cloud_properties:
-    instance_type: t3.large
-- name: c1.medium
-  cloud_properties:
+- cloud_properties:
     instance_type: c1.medium
-- name: t3a.small
-  cloud_properties:
-    instance_type: t3a.small
-- name: m5ad.8xlarge
-  cloud_properties:
-    instance_type: m5ad.8xlarge
-- name: m5a.2xlarge
-  cloud_properties:
-    instance_type: m5a.2xlarge
-- name: m5d.metal
-  cloud_properties:
-    instance_type: m5d.metal
-- name: r3.2xlarge
-  cloud_properties:
-    instance_type: r3.2xlarge
-- name: r4.16xlarge
-  cloud_properties:
-    instance_type: r4.16xlarge
-- name: c5d.4xlarge
-  cloud_properties:
-    instance_type: c5d.4xlarge
-- name: r5d.xlarge
-  cloud_properties:
-    instance_type: r5d.xlarge
-- name: m1.xlarge
-  cloud_properties:
-    instance_type: m1.xlarge
-- name: t3.2xlarge
-  cloud_properties:
-    instance_type: t3.2xlarge
-- name: m5ad.2xlarge
-  cloud_properties:
-    instance_type: m5ad.2xlarge
-- name: r5ad.large
-  cloud_properties:
-    instance_type: r5ad.large
-- name: m4.4xlarge
-  cloud_properties:
-    instance_type: m4.4xlarge
-- name: r5ad.8xlarge
-  cloud_properties:
-    instance_type: r5ad.8xlarge
-- name: m4.large
-  cloud_properties:
-    instance_type: m4.large
-- name: c4.large
-  cloud_properties:
-    instance_type: c4.large
-- name: m5.metal
-  cloud_properties:
-    instance_type: m5.metal
-- name: m5a.4xlarge
-  cloud_properties:
-    instance_type: m5a.4xlarge
-- name: m2.4xlarge
-  cloud_properties:
-    instance_type: m2.4xlarge
-- name: m2.2xlarge
-  cloud_properties:
-    instance_type: m2.2xlarge
-- name: t3.medium
-  cloud_properties:
-    instance_type: t3.medium
-- name: x1e.8xlarge
-  cloud_properties:
-    instance_type: x1e.8xlarge
-- name: m5ad.12xlarge
-  cloud_properties:
-    instance_type: m5ad.12xlarge
-- name: c5d.12xlarge
-  cloud_properties:
-    instance_type: c5d.12xlarge
-- name: c5d.24xlarge
-  cloud_properties:
-    instance_type: c5d.24xlarge
-- name: t2.large
-  cloud_properties:
-    instance_type: t2.large
-- name: r5ad.12xlarge
-  cloud_properties:
-    instance_type: r5ad.12xlarge
-- name: c4.4xlarge
-  cloud_properties:
-    instance_type: c4.4xlarge
-- name: t3a.2xlarge
-  cloud_properties:
-    instance_type: t3a.2xlarge
-- name: r5.metal
-  cloud_properties:
-    instance_type: r5.metal
-- name: m3.xlarge
-  cloud_properties:
-    instance_type: m3.xlarge
-- name: r5ad.24xlarge
-  cloud_properties:
-    instance_type: r5ad.24xlarge
-- name: m5.24xlarge
-  cloud_properties:
-    instance_type: m5.24xlarge
-- name: m5.8xlarge
-  cloud_properties:
-    instance_type: m5.8xlarge
-- name: r3.large
-  cloud_properties:
-    instance_type: r3.large
-- name: c5.24xlarge
-  cloud_properties:
-    instance_type: c5.24xlarge
-- name: r5.16xlarge
-  cloud_properties:
-    instance_type: r5.16xlarge
-- name: x1e.32xlarge
-  cloud_properties:
-    instance_type: x1e.32xlarge
-- name: m4.xlarge
-  cloud_properties:
-    instance_type: m4.xlarge
-- name: c5.xlarge
-  cloud_properties:
-    instance_type: c5.xlarge
-- name: m5d.8xlarge
-  cloud_properties:
-    instance_type: m5d.8xlarge
-- name: x1.16xlarge
-  cloud_properties:
-    instance_type: x1.16xlarge
-- name: c3.8xlarge
-  cloud_properties:
-    instance_type: c3.8xlarge
-- name: r5.large
-  cloud_properties:
-    instance_type: r5.large
-- name: c3.large
-  cloud_properties:
-    instance_type: c3.large
-- name: m5.12xlarge
-  cloud_properties:
-    instance_type: m5.12xlarge
-- name: r5a.xlarge
-  cloud_properties:
-    instance_type: r5a.xlarge
-- name: t1.micro
-  cloud_properties:
-    instance_type: t1.micro
-- name: t2.2xlarge
-  cloud_properties:
-    instance_type: t2.2xlarge
-- name: r5d.large
-  cloud_properties:
-    instance_type: r5d.large
-- name: x1e.2xlarge
-  cloud_properties:
-    instance_type: x1e.2xlarge
-- name: c4.8xlarge
-  cloud_properties:
-    instance_type: c4.8xlarge
-- name: m5ad.large
-  cloud_properties:
-    instance_type: m5ad.large
-- name: c5d.2xlarge
-  cloud_properties:
-    instance_type: c5d.2xlarge
-- name: r5.24xlarge
-  cloud_properties:
-    instance_type: r5.24xlarge
-- name: r5a.16xlarge
-  cloud_properties:
-    instance_type: r5a.16xlarge
-- name: c5n.2xlarge
-  cloud_properties:
-    instance_type: c5n.2xlarge
-- name: m5d.xlarge
-  cloud_properties:
-    instance_type: m5d.xlarge
-- name: c5.4xlarge
-  cloud_properties:
-    instance_type: c5.4xlarge
-- name: c3.xlarge
-  cloud_properties:
-    instance_type: c3.xlarge
-- name: r5a.2xlarge
-  cloud_properties:
-    instance_type: r5a.2xlarge
-- name: c5n.9xlarge
-  cloud_properties:
-    instance_type: c5n.9xlarge
-- name: c1.xlarge
-  cloud_properties:
+  name: c1.medium
+- cloud_properties:
     instance_type: c1.xlarge
-- name: c5d.large
-  cloud_properties:
-    instance_type: c5d.large
-- name: t3a.medium
-  cloud_properties:
-    instance_type: t3a.medium
-- name: c5n.large
-  cloud_properties:
-    instance_type: c5n.large
-- name: m5d.16xlarge
-  cloud_properties:
-    instance_type: m5d.16xlarge
-- name: x1.32xlarge
-  cloud_properties:
-    instance_type: x1.32xlarge
-- name: t2.nano
-  cloud_properties:
-    instance_type: t2.nano
-- name: m5a.8xlarge
-  cloud_properties:
-    instance_type: m5a.8xlarge
-- name: r5.8xlarge
-  cloud_properties:
-    instance_type: r5.8xlarge
-- name: c5n.xlarge
-  cloud_properties:
-    instance_type: c5n.xlarge
-- name: t3a.micro
-  cloud_properties:
-    instance_type: t3a.micro
-- name: m5.large
-  cloud_properties:
-    instance_type: m5.large
-- name: r5a.24xlarge
-  cloud_properties:
-    instance_type: r5a.24xlarge
-- name: r5d.12xlarge
-  cloud_properties:
-    instance_type: r5d.12xlarge
-- name: r4.xlarge
-  cloud_properties:
-    instance_type: r4.xlarge
-- name: m5d.2xlarge
-  cloud_properties:
-    instance_type: m5d.2xlarge
-- name: c3.4xlarge
-  cloud_properties:
-    instance_type: c3.4xlarge
-- name: m5a.24xlarge
-  cloud_properties:
-    instance_type: m5a.24xlarge
-- name: t3.micro
-  cloud_properties:
-    instance_type: t3.micro
-- name: m3.medium
-  cloud_properties:
-    instance_type: m3.medium
-- name: c5d.metal
-  cloud_properties:
-    instance_type: c5d.metal
-- name: x1e.4xlarge
-  cloud_properties:
-    instance_type: x1e.4xlarge
-- name: m5d.4xlarge
-  cloud_properties:
-    instance_type: m5d.4xlarge
-- name: r5d.8xlarge
-  cloud_properties:
-    instance_type: r5d.8xlarge
-- name: c5.9xlarge
-  cloud_properties:
-    instance_type: c5.9xlarge
-- name: c5n.18xlarge
-  cloud_properties:
-    instance_type: c5n.18xlarge
-- name: c3.2xlarge
-  cloud_properties:
+  name: c1.xlarge
+- cloud_properties:
     instance_type: c3.2xlarge
-- name: t3.nano
-  cloud_properties:
-    instance_type: t3.nano
-- name: r5d.24xlarge
-  cloud_properties:
-    instance_type: r5d.24xlarge
-- name: c4.xlarge
-  cloud_properties:
-    instance_type: c4.xlarge
-- name: m5.4xlarge
-  cloud_properties:
-    instance_type: m5.4xlarge
-- name: c5n.metal
-  cloud_properties:
-    instance_type: c5n.metal
-- name: r5d.metal
-  cloud_properties:
-    instance_type: r5d.metal
-- name: r5.xlarge
-  cloud_properties:
-    instance_type: r5.xlarge
-- name: c5d.18xlarge
-  cloud_properties:
-    instance_type: c5d.18xlarge
-- name: m3.2xlarge
-  cloud_properties:
-    instance_type: m3.2xlarge
-- name: r5a.8xlarge
-  cloud_properties:
-    instance_type: r5a.8xlarge
-- name: r4.large
-  cloud_properties:
-    instance_type: r4.large
-- name: m1.small
-  cloud_properties:
-    instance_type: m1.small
-- name: m5.16xlarge
-  cloud_properties:
-    instance_type: m5.16xlarge
-- name: r5.12xlarge
-  cloud_properties:
-    instance_type: r5.12xlarge
-- name: r5ad.4xlarge
-  cloud_properties:
-    instance_type: r5ad.4xlarge
-- name: m5d.12xlarge
-  cloud_properties:
-    instance_type: m5d.12xlarge
-- name: m5a.large
-  cloud_properties:
-    instance_type: m5a.large
-- name: x1e.xlarge
-  cloud_properties:
-    instance_type: x1e.xlarge
-- name: r4.4xlarge
-  cloud_properties:
-    instance_type: r4.4xlarge
-- name: t2.xlarge
-  cloud_properties:
-    instance_type: t2.xlarge
-- name: c5d.9xlarge
-  cloud_properties:
-    instance_type: c5d.9xlarge
-- name: m2.xlarge
-  cloud_properties:
-    instance_type: m2.xlarge
-- name: c5.2xlarge
-  cloud_properties:
-    instance_type: c5.2xlarge
-- name: r3.xlarge
-  cloud_properties:
-    instance_type: r3.xlarge
-- name: c5.large
-  cloud_properties:
-    instance_type: c5.large
-- name: t2.small
-  cloud_properties:
-    instance_type: t2.small
-- name: r5ad.xlarge
-  cloud_properties:
-    instance_type: r5ad.xlarge
-- name: t3a.nano
-  cloud_properties:
-    instance_type: t3a.nano
-- name: r4.8xlarge
-  cloud_properties:
-    instance_type: r4.8xlarge
-- name: m5ad.xlarge
-  cloud_properties:
-    instance_type: m5ad.xlarge
-- name: m4.2xlarge
-  cloud_properties:
-    instance_type: m4.2xlarge
-- name: t3a.large
-  cloud_properties:
-    instance_type: t3a.large
-- name: r5d.2xlarge
-  cloud_properties:
-    instance_type: r5d.2xlarge
-- name: m5a.12xlarge
-  cloud_properties:
-    instance_type: m5a.12xlarge
-- name: m5.2xlarge
-  cloud_properties:
-    instance_type: m5.2xlarge
-- name: c4.2xlarge
-  cloud_properties:
+  name: c3.2xlarge
+- cloud_properties:
+    instance_type: c3.4xlarge
+  name: c3.4xlarge
+- cloud_properties:
+    instance_type: c3.8xlarge
+  name: c3.8xlarge
+- cloud_properties:
+    instance_type: c3.large
+  name: c3.large
+- cloud_properties:
+    instance_type: c3.xlarge
+  name: c3.xlarge
+- cloud_properties:
     instance_type: c4.2xlarge
-- name: t2.medium
-  cloud_properties:
-    instance_type: t2.medium
-- name: r5ad.2xlarge
-  cloud_properties:
-    instance_type: r5ad.2xlarge
-- name: r5ad.16xlarge
-  cloud_properties:
-    instance_type: r5ad.16xlarge
-- name: m4.10xlarge
-  cloud_properties:
-    instance_type: m4.10xlarge
-- name: m3.large
-  cloud_properties:
-    instance_type: m3.large
-- name: r4.2xlarge
-  cloud_properties:
-    instance_type: r4.2xlarge
-- name: m5ad.16xlarge
-  cloud_properties:
-    instance_type: m5ad.16xlarge
-- name: c5.metal
-  cloud_properties:
-    instance_type: c5.metal
-- name: x1e.16xlarge
-  cloud_properties:
-    instance_type: x1e.16xlarge
-- name: m5d.24xlarge
-  cloud_properties:
-    instance_type: m5d.24xlarge
-- name: m5a.xlarge
-  cloud_properties:
-    instance_type: m5a.xlarge
-- name: r5.2xlarge
-  cloud_properties:
-    instance_type: r5.2xlarge
-- name: r5d.16xlarge
-  cloud_properties:
-    instance_type: r5d.16xlarge
-- name: m5ad.24xlarge
-  cloud_properties:
-    instance_type: m5ad.24xlarge
-- name: c5d.xlarge
-  cloud_properties:
-    instance_type: c5d.xlarge
-- name: t3.small
-  cloud_properties:
-    instance_type: t3.small
-- name: c5.18xlarge
-  cloud_properties:
+  name: c4.2xlarge
+- cloud_properties:
+    instance_type: c4.4xlarge
+  name: c4.4xlarge
+- cloud_properties:
+    instance_type: c4.8xlarge
+  name: c4.8xlarge
+- cloud_properties:
+    instance_type: c4.large
+  name: c4.large
+- cloud_properties:
+    instance_type: c4.xlarge
+  name: c4.xlarge
+- cloud_properties:
+    instance_type: c5.12xlarge
+  name: c5.12xlarge
+- cloud_properties:
     instance_type: c5.18xlarge
-- name: m1.medium
-  cloud_properties:
-    instance_type: m1.medium
-- name: t3a.xlarge
-  cloud_properties:
-    instance_type: t3a.xlarge
-- name: m1.large
-  cloud_properties:
+  name: c5.18xlarge
+- cloud_properties:
+    instance_type: c5.24xlarge
+  name: c5.24xlarge
+- cloud_properties:
+    instance_type: c5.2xlarge
+  name: c5.2xlarge
+- cloud_properties:
+    instance_type: c5.4xlarge
+  name: c5.4xlarge
+- cloud_properties:
+    instance_type: c5.9xlarge
+  name: c5.9xlarge
+- cloud_properties:
+    instance_type: c5.large
+  name: c5.large
+- cloud_properties:
+    instance_type: c5.metal
+  name: c5.metal
+- cloud_properties:
+    instance_type: c5.xlarge
+  name: c5.xlarge
+- cloud_properties:
+    instance_type: c5d.12xlarge
+  name: c5d.12xlarge
+- cloud_properties:
+    instance_type: c5d.18xlarge
+  name: c5d.18xlarge
+- cloud_properties:
+    instance_type: c5d.24xlarge
+  name: c5d.24xlarge
+- cloud_properties:
+    instance_type: c5d.2xlarge
+  name: c5d.2xlarge
+- cloud_properties:
+    instance_type: c5d.4xlarge
+  name: c5d.4xlarge
+- cloud_properties:
+    instance_type: c5d.9xlarge
+  name: c5d.9xlarge
+- cloud_properties:
+    instance_type: c5d.large
+  name: c5d.large
+- cloud_properties:
+    instance_type: c5d.metal
+  name: c5d.metal
+- cloud_properties:
+    instance_type: c5d.xlarge
+  name: c5d.xlarge
+- cloud_properties:
+    instance_type: c5n.18xlarge
+  name: c5n.18xlarge
+- cloud_properties:
+    instance_type: c5n.2xlarge
+  name: c5n.2xlarge
+- cloud_properties:
+    instance_type: c5n.4xlarge
+  name: c5n.4xlarge
+- cloud_properties:
+    instance_type: c5n.9xlarge
+  name: c5n.9xlarge
+- cloud_properties:
+    instance_type: c5n.large
+  name: c5n.large
+- cloud_properties:
+    instance_type: c5n.metal
+  name: c5n.metal
+- cloud_properties:
+    instance_type: c5n.xlarge
+  name: c5n.xlarge
+- cloud_properties:
     instance_type: m1.large
+  name: m1.large
+- cloud_properties:
+    instance_type: m1.medium
+  name: m1.medium
+- cloud_properties:
+    instance_type: m1.small
+  name: m1.small
+- cloud_properties:
+    instance_type: m1.xlarge
+  name: m1.xlarge
+- cloud_properties:
+    instance_type: m2.2xlarge
+  name: m2.2xlarge
+- cloud_properties:
+    instance_type: m2.4xlarge
+  name: m2.4xlarge
+- cloud_properties:
+    instance_type: m2.xlarge
+  name: m2.xlarge
+- cloud_properties:
+    instance_type: m3.2xlarge
+  name: m3.2xlarge
+- cloud_properties:
+    instance_type: m3.large
+  name: m3.large
+- cloud_properties:
+    instance_type: m3.medium
+  name: m3.medium
+- cloud_properties:
+    instance_type: m3.xlarge
+  name: m3.xlarge
+- cloud_properties:
+    instance_type: m4.10xlarge
+  name: m4.10xlarge
+- cloud_properties:
+    instance_type: m4.16xlarge
+  name: m4.16xlarge
+- cloud_properties:
+    instance_type: m4.2xlarge
+  name: m4.2xlarge
+- cloud_properties:
+    instance_type: m4.4xlarge
+  name: m4.4xlarge
+- cloud_properties:
+    instance_type: m4.large
+  name: m4.large
+- cloud_properties:
+    instance_type: m4.xlarge
+  name: m4.xlarge
+- cloud_properties:
+    instance_type: m5.12xlarge
+  name: m5.12xlarge
+- cloud_properties:
+    instance_type: m5.16xlarge
+  name: m5.16xlarge
+- cloud_properties:
+    instance_type: m5.24xlarge
+  name: m5.24xlarge
+- cloud_properties:
+    instance_type: m5.2xlarge
+  name: m5.2xlarge
+- cloud_properties:
+    instance_type: m5.4xlarge
+  name: m5.4xlarge
+- cloud_properties:
+    instance_type: m5.8xlarge
+  name: m5.8xlarge
+- cloud_properties:
+    instance_type: m5.large
+  name: m5.large
+- cloud_properties:
+    instance_type: m5.metal
+  name: m5.metal
+- cloud_properties:
+    instance_type: m5.xlarge
+  name: m5.xlarge
+- cloud_properties:
+    instance_type: m5a.12xlarge
+  name: m5a.12xlarge
+- cloud_properties:
+    instance_type: m5a.16xlarge
+  name: m5a.16xlarge
+- cloud_properties:
+    instance_type: m5a.24xlarge
+  name: m5a.24xlarge
+- cloud_properties:
+    instance_type: m5a.2xlarge
+  name: m5a.2xlarge
+- cloud_properties:
+    instance_type: m5a.4xlarge
+  name: m5a.4xlarge
+- cloud_properties:
+    instance_type: m5a.8xlarge
+  name: m5a.8xlarge
+- cloud_properties:
+    instance_type: m5a.large
+  name: m5a.large
+- cloud_properties:
+    instance_type: m5a.xlarge
+  name: m5a.xlarge
+- cloud_properties:
+    instance_type: m5ad.12xlarge
+  name: m5ad.12xlarge
+- cloud_properties:
+    instance_type: m5ad.16xlarge
+  name: m5ad.16xlarge
+- cloud_properties:
+    instance_type: m5ad.24xlarge
+  name: m5ad.24xlarge
+- cloud_properties:
+    instance_type: m5ad.2xlarge
+  name: m5ad.2xlarge
+- cloud_properties:
+    instance_type: m5ad.4xlarge
+  name: m5ad.4xlarge
+- cloud_properties:
+    instance_type: m5ad.8xlarge
+  name: m5ad.8xlarge
+- cloud_properties:
+    instance_type: m5ad.large
+  name: m5ad.large
+- cloud_properties:
+    instance_type: m5ad.xlarge
+  name: m5ad.xlarge
+- cloud_properties:
+    instance_type: m5d.12xlarge
+  name: m5d.12xlarge
+- cloud_properties:
+    instance_type: m5d.16xlarge
+  name: m5d.16xlarge
+- cloud_properties:
+    instance_type: m5d.24xlarge
+  name: m5d.24xlarge
+- cloud_properties:
+    instance_type: m5d.2xlarge
+  name: m5d.2xlarge
+- cloud_properties:
+    instance_type: m5d.4xlarge
+  name: m5d.4xlarge
+- cloud_properties:
+    instance_type: m5d.8xlarge
+  name: m5d.8xlarge
+- cloud_properties:
+    instance_type: m5d.large
+  name: m5d.large
+- cloud_properties:
+    instance_type: m5d.metal
+  name: m5d.metal
+- cloud_properties:
+    instance_type: m5d.xlarge
+  name: m5d.xlarge
+- cloud_properties:
+    instance_type: r3.2xlarge
+  name: r3.2xlarge
+- cloud_properties:
+    instance_type: r3.4xlarge
+  name: r3.4xlarge
+- cloud_properties:
+    instance_type: r3.8xlarge
+  name: r3.8xlarge
+- cloud_properties:
+    instance_type: r3.large
+  name: r3.large
+- cloud_properties:
+    instance_type: r3.xlarge
+  name: r3.xlarge
+- cloud_properties:
+    instance_type: r4.16xlarge
+  name: r4.16xlarge
+- cloud_properties:
+    instance_type: r4.2xlarge
+  name: r4.2xlarge
+- cloud_properties:
+    instance_type: r4.4xlarge
+  name: r4.4xlarge
+- cloud_properties:
+    instance_type: r4.8xlarge
+  name: r4.8xlarge
+- cloud_properties:
+    instance_type: r4.large
+  name: r4.large
+- cloud_properties:
+    instance_type: r4.xlarge
+  name: r4.xlarge
+- cloud_properties:
+    instance_type: r5.12xlarge
+  name: r5.12xlarge
+- cloud_properties:
+    instance_type: r5.16xlarge
+  name: r5.16xlarge
+- cloud_properties:
+    instance_type: r5.24xlarge
+  name: r5.24xlarge
+- cloud_properties:
+    instance_type: r5.2xlarge
+  name: r5.2xlarge
+- cloud_properties:
+    instance_type: r5.4xlarge
+  name: r5.4xlarge
+- cloud_properties:
+    instance_type: r5.8xlarge
+  name: r5.8xlarge
+- cloud_properties:
+    instance_type: r5.large
+  name: r5.large
+- cloud_properties:
+    instance_type: r5.metal
+  name: r5.metal
+- cloud_properties:
+    instance_type: r5.xlarge
+  name: r5.xlarge
+- cloud_properties:
+    instance_type: r5a.12xlarge
+  name: r5a.12xlarge
+- cloud_properties:
+    instance_type: r5a.16xlarge
+  name: r5a.16xlarge
+- cloud_properties:
+    instance_type: r5a.24xlarge
+  name: r5a.24xlarge
+- cloud_properties:
+    instance_type: r5a.2xlarge
+  name: r5a.2xlarge
+- cloud_properties:
+    instance_type: r5a.4xlarge
+  name: r5a.4xlarge
+- cloud_properties:
+    instance_type: r5a.8xlarge
+  name: r5a.8xlarge
+- cloud_properties:
+    instance_type: r5a.large
+  name: r5a.large
+- cloud_properties:
+    instance_type: r5a.xlarge
+  name: r5a.xlarge
+- cloud_properties:
+    instance_type: r5ad.12xlarge
+  name: r5ad.12xlarge
+- cloud_properties:
+    instance_type: r5ad.16xlarge
+  name: r5ad.16xlarge
+- cloud_properties:
+    instance_type: r5ad.24xlarge
+  name: r5ad.24xlarge
+- cloud_properties:
+    instance_type: r5ad.2xlarge
+  name: r5ad.2xlarge
+- cloud_properties:
+    instance_type: r5ad.4xlarge
+  name: r5ad.4xlarge
+- cloud_properties:
+    instance_type: r5ad.8xlarge
+  name: r5ad.8xlarge
+- cloud_properties:
+    instance_type: r5ad.large
+  name: r5ad.large
+- cloud_properties:
+    instance_type: r5ad.xlarge
+  name: r5ad.xlarge
+- cloud_properties:
+    instance_type: r5d.12xlarge
+  name: r5d.12xlarge
+- cloud_properties:
+    instance_type: r5d.16xlarge
+  name: r5d.16xlarge
+- cloud_properties:
+    instance_type: r5d.24xlarge
+  name: r5d.24xlarge
+- cloud_properties:
+    instance_type: r5d.2xlarge
+  name: r5d.2xlarge
+- cloud_properties:
+    instance_type: r5d.4xlarge
+  name: r5d.4xlarge
+- cloud_properties:
+    instance_type: r5d.8xlarge
+  name: r5d.8xlarge
+- cloud_properties:
+    instance_type: r5d.large
+  name: r5d.large
+- cloud_properties:
+    instance_type: r5d.metal
+  name: r5d.metal
+- cloud_properties:
+    instance_type: r5d.xlarge
+  name: r5d.xlarge
+- cloud_properties:
+    instance_type: t1.micro
+  name: t1.micro
+- cloud_properties:
+    instance_type: t2.2xlarge
+  name: t2.2xlarge
+- cloud_properties:
+    instance_type: t2.large
+  name: t2.large
+- cloud_properties:
+    instance_type: t2.medium
+  name: t2.medium
+- cloud_properties:
+    instance_type: t2.micro
+  name: t2.micro
+- cloud_properties:
+    instance_type: t2.nano
+  name: t2.nano
+- cloud_properties:
+    instance_type: t2.small
+  name: t2.small
+- cloud_properties:
+    instance_type: t2.xlarge
+  name: t2.xlarge
+- cloud_properties:
+    instance_type: t3.2xlarge
+  name: t3.2xlarge
+- cloud_properties:
+    instance_type: t3.large
+  name: t3.large
+- cloud_properties:
+    instance_type: t3.medium
+  name: t3.medium
+- cloud_properties:
+    instance_type: t3.micro
+  name: t3.micro
+- cloud_properties:
+    instance_type: t3.nano
+  name: t3.nano
+- cloud_properties:
+    instance_type: t3.small
+  name: t3.small
+- cloud_properties:
+    instance_type: t3.xlarge
+  name: t3.xlarge
+- cloud_properties:
+    instance_type: t3a.2xlarge
+  name: t3a.2xlarge
+- cloud_properties:
+    instance_type: t3a.large
+  name: t3a.large
+- cloud_properties:
+    instance_type: t3a.medium
+  name: t3a.medium
+- cloud_properties:
+    instance_type: t3a.micro
+  name: t3a.micro
+- cloud_properties:
+    instance_type: t3a.nano
+  name: t3a.nano
+- cloud_properties:
+    instance_type: t3a.small
+  name: t3a.small
+- cloud_properties:
+    instance_type: t3a.xlarge
+  name: t3a.xlarge
+- cloud_properties:
+    instance_type: x1.16xlarge
+  name: x1.16xlarge
+- cloud_properties:
+    instance_type: x1.32xlarge
+  name: x1.32xlarge
+- cloud_properties:
+    instance_type: x1e.16xlarge
+  name: x1e.16xlarge
+- cloud_properties:
+    instance_type: x1e.2xlarge
+  name: x1e.2xlarge
+- cloud_properties:
+    instance_type: x1e.32xlarge
+  name: x1e.32xlarge
+- cloud_properties:
+    instance_type: x1e.4xlarge
+  name: x1e.4xlarge
+- cloud_properties:
+    instance_type: x1e.8xlarge
+  name: x1e.8xlarge
+- cloud_properties:
+    instance_type: x1e.xlarge
+  name: x1e.xlarge
 
 vm_extensions:
 - name: errand-profile

--- a/cloud-config/base.yml
+++ b/cloud-config/base.yml
@@ -19,6 +19,624 @@ vm_types:
 - name: errand_large
   cloud_properties:
     instance_type: m4.large
+- name: m5.xlarge
+  cloud_properties:
+    instance_type: m5.xlarge
+- name: r5d.4xlarge
+  cloud_properties:
+    instance_type: r5d.4xlarge
+- name: g3.8xlarge
+  cloud_properties:
+    instance_type: g3.8xlarge
+- name: m5ad.4xlarge
+  cloud_properties:
+    instance_type: m5ad.4xlarge
+- name: m4.16xlarge
+  cloud_properties:
+    instance_type: m4.16xlarge
+- name: r3.4xlarge
+  cloud_properties:
+    instance_type: r3.4xlarge
+- name: i2.xlarge
+  cloud_properties:
+    instance_type: i2.xlarge
+- name: m5d.large
+  cloud_properties:
+    instance_type: m5d.large
+- name: r5.4xlarge
+  cloud_properties:
+    instance_type: r5.4xlarge
+- name: c5.12xlarge
+  cloud_properties:
+    instance_type: c5.12xlarge
+- name: c5n.4xlarge
+  cloud_properties:
+    instance_type: c5n.4xlarge
+- name: r5a.4xlarge
+  cloud_properties:
+    instance_type: r5a.4xlarge
+- name: t3.xlarge
+  cloud_properties:
+    instance_type: t3.xlarge
+- name: r5a.12xlarge
+  cloud_properties:
+    instance_type: r5a.12xlarge
+- name: r5a.large
+  cloud_properties:
+    instance_type: r5a.large
+- name: m5a.16xlarge
+  cloud_properties:
+    instance_type: m5a.16xlarge
+- name: r3.8xlarge
+  cloud_properties:
+    instance_type: r3.8xlarge
+- name: i3en.24xlarge
+  cloud_properties:
+    instance_type: i3en.24xlarge
+- name: t2.micro
+  cloud_properties:
+    instance_type: t2.micro
+- name: t3.large
+  cloud_properties:
+    instance_type: t3.large
+- name: c1.medium
+  cloud_properties:
+    instance_type: c1.medium
+- name: t3a.small
+  cloud_properties:
+    instance_type: t3a.small
+- name: m5ad.8xlarge
+  cloud_properties:
+    instance_type: m5ad.8xlarge
+- name: g3.4xlarge
+  cloud_properties:
+    instance_type: g3.4xlarge
+- name: m5a.2xlarge
+  cloud_properties:
+    instance_type: m5a.2xlarge
+- name: i3en.3xlarge
+  cloud_properties:
+    instance_type: i3en.3xlarge
+- name: m5d.metal
+  cloud_properties:
+    instance_type: m5d.metal
+- name: r3.2xlarge
+  cloud_properties:
+    instance_type: r3.2xlarge
+- name: r4.16xlarge
+  cloud_properties:
+    instance_type: r4.16xlarge
+- name: c5d.4xlarge
+  cloud_properties:
+    instance_type: c5d.4xlarge
+- name: r5d.xlarge
+  cloud_properties:
+    instance_type: r5d.xlarge
+- name: m1.xlarge
+  cloud_properties:
+    instance_type: m1.xlarge
+- name: t3.2xlarge
+  cloud_properties:
+    instance_type: t3.2xlarge
+- name: m5ad.2xlarge
+  cloud_properties:
+    instance_type: m5ad.2xlarge
+- name: r5ad.large
+  cloud_properties:
+    instance_type: r5ad.large
+- name: m4.4xlarge
+  cloud_properties:
+    instance_type: m4.4xlarge
+- name: r5ad.8xlarge
+  cloud_properties:
+    instance_type: r5ad.8xlarge
+- name: d2.2xlarge
+  cloud_properties:
+    instance_type: d2.2xlarge
+- name: m4.large
+  cloud_properties:
+    instance_type: m4.large
+- name: c4.large
+  cloud_properties:
+    instance_type: c4.large
+- name: m5.metal
+  cloud_properties:
+    instance_type: m5.metal
+- name: p2.8xlarge
+  cloud_properties:
+    instance_type: p2.8xlarge
+- name: i3en.12xlarge
+  cloud_properties:
+    instance_type: i3en.12xlarge
+- name: m5a.4xlarge
+  cloud_properties:
+    instance_type: m5a.4xlarge
+- name: m2.4xlarge
+  cloud_properties:
+    instance_type: m2.4xlarge
+- name: m2.2xlarge
+  cloud_properties:
+    instance_type: m2.2xlarge
+- name: t3.medium
+  cloud_properties:
+    instance_type: t3.medium
+- name: x1e.8xlarge
+  cloud_properties:
+    instance_type: x1e.8xlarge
+- name: m5ad.12xlarge
+  cloud_properties:
+    instance_type: m5ad.12xlarge
+- name: c5d.12xlarge
+  cloud_properties:
+    instance_type: c5d.12xlarge
+- name: c5d.24xlarge
+  cloud_properties:
+    instance_type: c5d.24xlarge
+- name: t2.large
+  cloud_properties:
+    instance_type: t2.large
+- name: i2.2xlarge
+  cloud_properties:
+    instance_type: i2.2xlarge
+- name: g3.16xlarge
+  cloud_properties:
+    instance_type: g3.16xlarge
+- name: r5ad.12xlarge
+  cloud_properties:
+    instance_type: r5ad.12xlarge
+- name: c4.4xlarge
+  cloud_properties:
+    instance_type: c4.4xlarge
+- name: t3a.2xlarge
+  cloud_properties:
+    instance_type: t3a.2xlarge
+- name: r5.metal
+  cloud_properties:
+    instance_type: r5.metal
+- name: m3.xlarge
+  cloud_properties:
+    instance_type: m3.xlarge
+- name: d2.8xlarge
+  cloud_properties:
+    instance_type: d2.8xlarge
+- name: f1.2xlarge
+  cloud_properties:
+    instance_type: f1.2xlarge
+- name: p3.2xlarge
+  cloud_properties:
+    instance_type: p3.2xlarge
+- name: r5ad.24xlarge
+  cloud_properties:
+    instance_type: r5ad.24xlarge
+- name: g4dn.12xlarge
+  cloud_properties:
+    instance_type: g4dn.12xlarge
+- name: m5.24xlarge
+  cloud_properties:
+    instance_type: m5.24xlarge
+- name: m5.8xlarge
+  cloud_properties:
+    instance_type: m5.8xlarge
+- name: r3.large
+  cloud_properties:
+    instance_type: r3.large
+- name: c5.24xlarge
+  cloud_properties:
+    instance_type: c5.24xlarge
+- name: r5.16xlarge
+  cloud_properties:
+    instance_type: r5.16xlarge
+- name: x1e.32xlarge
+  cloud_properties:
+    instance_type: x1e.32xlarge
+- name: m4.xlarge
+  cloud_properties:
+    instance_type: m4.xlarge
+- name: c5.xlarge
+  cloud_properties:
+    instance_type: c5.xlarge
+- name: m5d.8xlarge
+  cloud_properties:
+    instance_type: m5d.8xlarge
+- name: x1.16xlarge
+  cloud_properties:
+    instance_type: x1.16xlarge
+- name: c3.8xlarge
+  cloud_properties:
+    instance_type: c3.8xlarge
+- name: r5.large
+  cloud_properties:
+    instance_type: r5.large
+- name: c3.large
+  cloud_properties:
+    instance_type: c3.large
+- name: m5.12xlarge
+  cloud_properties:
+    instance_type: m5.12xlarge
+- name: r5a.xlarge
+  cloud_properties:
+    instance_type: r5a.xlarge
+- name: t1.micro
+  cloud_properties:
+    instance_type: t1.micro
+- name: t2.2xlarge
+  cloud_properties:
+    instance_type: t2.2xlarge
+- name: r5d.large
+  cloud_properties:
+    instance_type: r5d.large
+- name: x1e.2xlarge
+  cloud_properties:
+    instance_type: x1e.2xlarge
+- name: g4dn.metal
+  cloud_properties:
+    instance_type: g4dn.metal
+- name: c4.8xlarge
+  cloud_properties:
+    instance_type: c4.8xlarge
+- name: m5ad.large
+  cloud_properties:
+    instance_type: m5ad.large
+- name: c5d.2xlarge
+  cloud_properties:
+    instance_type: c5d.2xlarge
+- name: r5.24xlarge
+  cloud_properties:
+    instance_type: r5.24xlarge
+- name: r5a.16xlarge
+  cloud_properties:
+    instance_type: r5a.16xlarge
+- name: c5n.2xlarge
+  cloud_properties:
+    instance_type: c5n.2xlarge
+- name: m5d.xlarge
+  cloud_properties:
+    instance_type: m5d.xlarge
+- name: c5.4xlarge
+  cloud_properties:
+    instance_type: c5.4xlarge
+- name: c3.xlarge
+  cloud_properties:
+    instance_type: c3.xlarge
+- name: r5a.2xlarge
+  cloud_properties:
+    instance_type: r5a.2xlarge
+- name: c5n.9xlarge
+  cloud_properties:
+    instance_type: c5n.9xlarge
+- name: c1.xlarge
+  cloud_properties:
+    instance_type: c1.xlarge
+- name: c5d.large
+  cloud_properties:
+    instance_type: c5d.large
+- name: t3a.medium
+  cloud_properties:
+    instance_type: t3a.medium
+- name: c5n.large
+  cloud_properties:
+    instance_type: c5n.large
+- name: m5d.16xlarge
+  cloud_properties:
+    instance_type: m5d.16xlarge
+- name: x1.32xlarge
+  cloud_properties:
+    instance_type: x1.32xlarge
+- name: t2.nano
+  cloud_properties:
+    instance_type: t2.nano
+- name: i3.16xlarge
+  cloud_properties:
+    instance_type: i3.16xlarge
+- name: m5a.8xlarge
+  cloud_properties:
+    instance_type: m5a.8xlarge
+- name: r5.8xlarge
+  cloud_properties:
+    instance_type: r5.8xlarge
+- name: i2.4xlarge
+  cloud_properties:
+    instance_type: i2.4xlarge
+- name: g4dn.4xlarge
+  cloud_properties:
+    instance_type: g4dn.4xlarge
+- name: c5n.xlarge
+  cloud_properties:
+    instance_type: c5n.xlarge
+- name: t3a.micro
+  cloud_properties:
+    instance_type: t3a.micro
+- name: m5.large
+  cloud_properties:
+    instance_type: m5.large
+- name: r5a.24xlarge
+  cloud_properties:
+    instance_type: r5a.24xlarge
+- name: r5d.12xlarge
+  cloud_properties:
+    instance_type: r5d.12xlarge
+- name: r4.xlarge
+  cloud_properties:
+    instance_type: r4.xlarge
+- name: m5d.2xlarge
+  cloud_properties:
+    instance_type: m5d.2xlarge
+- name: c3.4xlarge
+  cloud_properties:
+    instance_type: c3.4xlarge
+- name: d2.xlarge
+  cloud_properties:
+    instance_type: d2.xlarge
+- name: p3dn.24xlarge
+  cloud_properties:
+    instance_type: p3dn.24xlarge
+- name: m5a.24xlarge
+  cloud_properties:
+    instance_type: m5a.24xlarge
+- name: t3.micro
+  cloud_properties:
+    instance_type: t3.micro
+- name: m3.medium
+  cloud_properties:
+    instance_type: m3.medium
+- name: c5d.metal
+  cloud_properties:
+    instance_type: c5d.metal
+- name: x1e.4xlarge
+  cloud_properties:
+    instance_type: x1e.4xlarge
+- name: m5d.4xlarge
+  cloud_properties:
+    instance_type: m5d.4xlarge
+- name: r5d.8xlarge
+  cloud_properties:
+    instance_type: r5d.8xlarge
+- name: f1.4xlarge
+  cloud_properties:
+    instance_type: f1.4xlarge
+- name: g4dn.xlarge
+  cloud_properties:
+    instance_type: g4dn.xlarge
+- name: g4dn.8xlarge
+  cloud_properties:
+    instance_type: g4dn.8xlarge
+- name: c5.9xlarge
+  cloud_properties:
+    instance_type: c5.9xlarge
+- name: c5n.18xlarge
+  cloud_properties:
+    instance_type: c5n.18xlarge
+- name: c3.2xlarge
+  cloud_properties:
+    instance_type: c3.2xlarge
+- name: t3.nano
+  cloud_properties:
+    instance_type: t3.nano
+- name: r5d.24xlarge
+  cloud_properties:
+    instance_type: r5d.24xlarge
+- name: c4.xlarge
+  cloud_properties:
+    instance_type: c4.xlarge
+- name: m5.4xlarge
+  cloud_properties:
+    instance_type: m5.4xlarge
+- name: f1.16xlarge
+  cloud_properties:
+    instance_type: f1.16xlarge
+- name: p3.8xlarge
+  cloud_properties:
+    instance_type: p3.8xlarge
+- name: c5n.metal
+  cloud_properties:
+    instance_type: c5n.metal
+- name: i3en.xlarge
+  cloud_properties:
+    instance_type: i3en.xlarge
+- name: r5d.metal
+  cloud_properties:
+    instance_type: r5d.metal
+- name: r5.xlarge
+  cloud_properties:
+    instance_type: r5.xlarge
+- name: i3.large
+  cloud_properties:
+    instance_type: i3.large
+- name: c5d.18xlarge
+  cloud_properties:
+    instance_type: c5d.18xlarge
+- name: i3.xlarge
+  cloud_properties:
+    instance_type: i3.xlarge
+- name: m3.2xlarge
+  cloud_properties:
+    instance_type: m3.2xlarge
+- name: r5a.8xlarge
+  cloud_properties:
+    instance_type: r5a.8xlarge
+- name: r4.large
+  cloud_properties:
+    instance_type: r4.large
+- name: m1.small
+  cloud_properties:
+    instance_type: m1.small
+- name: m5.16xlarge
+  cloud_properties:
+    instance_type: m5.16xlarge
+- name: r5.12xlarge
+  cloud_properties:
+    instance_type: r5.12xlarge
+- name: r5ad.4xlarge
+  cloud_properties:
+    instance_type: r5ad.4xlarge
+- name: m5d.12xlarge
+  cloud_properties:
+    instance_type: m5d.12xlarge
+- name: m5a.large
+  cloud_properties:
+    instance_type: m5a.large
+- name: i3en.2xlarge
+  cloud_properties:
+    instance_type: i3en.2xlarge
+- name: x1e.xlarge
+  cloud_properties:
+    instance_type: x1e.xlarge
+- name: r4.4xlarge
+  cloud_properties:
+    instance_type: r4.4xlarge
+- name: g4dn.16xlarge
+  cloud_properties:
+    instance_type: g4dn.16xlarge
+- name: t2.xlarge
+  cloud_properties:
+    instance_type: t2.xlarge
+- name: c5d.9xlarge
+  cloud_properties:
+    instance_type: c5d.9xlarge
+- name: m2.xlarge
+  cloud_properties:
+    instance_type: m2.xlarge
+- name: i3.2xlarge
+  cloud_properties:
+    instance_type: i3.2xlarge
+- name: c5.2xlarge
+  cloud_properties:
+    instance_type: c5.2xlarge
+- name: i3.metal
+  cloud_properties:
+    instance_type: i3.metal
+- name: r3.xlarge
+  cloud_properties:
+    instance_type: r3.xlarge
+- name: c5.large
+  cloud_properties:
+    instance_type: c5.large
+- name: t2.small
+  cloud_properties:
+    instance_type: t2.small
+- name: r5ad.xlarge
+  cloud_properties:
+    instance_type: r5ad.xlarge
+- name: t3a.nano
+  cloud_properties:
+    instance_type: t3a.nano
+- name: r4.8xlarge
+  cloud_properties:
+    instance_type: r4.8xlarge
+- name: m5ad.xlarge
+  cloud_properties:
+    instance_type: m5ad.xlarge
+- name: m4.2xlarge
+  cloud_properties:
+    instance_type: m4.2xlarge
+- name: i2.8xlarge
+  cloud_properties:
+    instance_type: i2.8xlarge
+- name: t3a.large
+  cloud_properties:
+    instance_type: t3a.large
+- name: r5d.2xlarge
+  cloud_properties:
+    instance_type: r5d.2xlarge
+- name: m5a.12xlarge
+  cloud_properties:
+    instance_type: m5a.12xlarge
+- name: m5.2xlarge
+  cloud_properties:
+    instance_type: m5.2xlarge
+- name: i3.4xlarge
+  cloud_properties:
+    instance_type: i3.4xlarge
+- name: c4.2xlarge
+  cloud_properties:
+    instance_type: c4.2xlarge
+- name: t2.medium
+  cloud_properties:
+    instance_type: t2.medium
+- name: p2.16xlarge
+  cloud_properties:
+    instance_type: p2.16xlarge
+- name: r5ad.2xlarge
+  cloud_properties:
+    instance_type: r5ad.2xlarge
+- name: r5ad.16xlarge
+  cloud_properties:
+    instance_type: r5ad.16xlarge
+- name: i3.8xlarge
+  cloud_properties:
+    instance_type: i3.8xlarge
+- name: d2.4xlarge
+  cloud_properties:
+    instance_type: d2.4xlarge
+- name: m4.10xlarge
+  cloud_properties:
+    instance_type: m4.10xlarge
+- name: m3.large
+  cloud_properties:
+    instance_type: m3.large
+- name: r4.2xlarge
+  cloud_properties:
+    instance_type: r4.2xlarge
+- name: p2.xlarge
+  cloud_properties:
+    instance_type: p2.xlarge
+- name: p3.16xlarge
+  cloud_properties:
+    instance_type: p3.16xlarge
+- name: m5ad.16xlarge
+  cloud_properties:
+    instance_type: m5ad.16xlarge
+- name: c5.metal
+  cloud_properties:
+    instance_type: c5.metal
+- name: x1e.16xlarge
+  cloud_properties:
+    instance_type: x1e.16xlarge
+- name: i3en.metal
+  cloud_properties:
+    instance_type: i3en.metal
+- name: m5d.24xlarge
+  cloud_properties:
+    instance_type: m5d.24xlarge
+- name: m5a.xlarge
+  cloud_properties:
+    instance_type: m5a.xlarge
+- name: r5.2xlarge
+  cloud_properties:
+    instance_type: r5.2xlarge
+- name: r5d.16xlarge
+  cloud_properties:
+    instance_type: r5d.16xlarge
+- name: i3en.large
+  cloud_properties:
+    instance_type: i3en.large
+- name: m5ad.24xlarge
+  cloud_properties:
+    instance_type: m5ad.24xlarge
+- name: c5d.xlarge
+  cloud_properties:
+    instance_type: c5d.xlarge
+- name: t3.small
+  cloud_properties:
+    instance_type: t3.small
+- name: c5.18xlarge
+  cloud_properties:
+    instance_type: c5.18xlarge
+- name: g4dn.2xlarge
+  cloud_properties:
+    instance_type: g4dn.2xlarge
+- name: i3en.6xlarge
+  cloud_properties:
+    instance_type: i3en.6xlarge
+- name: m1.medium
+  cloud_properties:
+    instance_type: m1.medium
+- name: t3a.xlarge
+  cloud_properties:
+    instance_type: t3a.xlarge
+- name: m1.large
+  cloud_properties:
+    instance_type: m1.large
 
 vm_extensions:
 - name: errand-profile

--- a/cloud-config/base.yml
+++ b/cloud-config/base.yml
@@ -25,9 +25,6 @@ vm_types:
 - name: r5d.4xlarge
   cloud_properties:
     instance_type: r5d.4xlarge
-- name: g3.8xlarge
-  cloud_properties:
-    instance_type: g3.8xlarge
 - name: m5ad.4xlarge
   cloud_properties:
     instance_type: m5ad.4xlarge
@@ -37,9 +34,6 @@ vm_types:
 - name: r3.4xlarge
   cloud_properties:
     instance_type: r3.4xlarge
-- name: i2.xlarge
-  cloud_properties:
-    instance_type: i2.xlarge
 - name: m5d.large
   cloud_properties:
     instance_type: m5d.large
@@ -70,9 +64,6 @@ vm_types:
 - name: r3.8xlarge
   cloud_properties:
     instance_type: r3.8xlarge
-- name: i3en.24xlarge
-  cloud_properties:
-    instance_type: i3en.24xlarge
 - name: t2.micro
   cloud_properties:
     instance_type: t2.micro
@@ -88,15 +79,9 @@ vm_types:
 - name: m5ad.8xlarge
   cloud_properties:
     instance_type: m5ad.8xlarge
-- name: g3.4xlarge
-  cloud_properties:
-    instance_type: g3.4xlarge
 - name: m5a.2xlarge
   cloud_properties:
     instance_type: m5a.2xlarge
-- name: i3en.3xlarge
-  cloud_properties:
-    instance_type: i3en.3xlarge
 - name: m5d.metal
   cloud_properties:
     instance_type: m5d.metal
@@ -130,9 +115,6 @@ vm_types:
 - name: r5ad.8xlarge
   cloud_properties:
     instance_type: r5ad.8xlarge
-- name: d2.2xlarge
-  cloud_properties:
-    instance_type: d2.2xlarge
 - name: m4.large
   cloud_properties:
     instance_type: m4.large
@@ -142,12 +124,6 @@ vm_types:
 - name: m5.metal
   cloud_properties:
     instance_type: m5.metal
-- name: p2.8xlarge
-  cloud_properties:
-    instance_type: p2.8xlarge
-- name: i3en.12xlarge
-  cloud_properties:
-    instance_type: i3en.12xlarge
 - name: m5a.4xlarge
   cloud_properties:
     instance_type: m5a.4xlarge
@@ -175,12 +151,6 @@ vm_types:
 - name: t2.large
   cloud_properties:
     instance_type: t2.large
-- name: i2.2xlarge
-  cloud_properties:
-    instance_type: i2.2xlarge
-- name: g3.16xlarge
-  cloud_properties:
-    instance_type: g3.16xlarge
 - name: r5ad.12xlarge
   cloud_properties:
     instance_type: r5ad.12xlarge
@@ -196,21 +166,9 @@ vm_types:
 - name: m3.xlarge
   cloud_properties:
     instance_type: m3.xlarge
-- name: d2.8xlarge
-  cloud_properties:
-    instance_type: d2.8xlarge
-- name: f1.2xlarge
-  cloud_properties:
-    instance_type: f1.2xlarge
-- name: p3.2xlarge
-  cloud_properties:
-    instance_type: p3.2xlarge
 - name: r5ad.24xlarge
   cloud_properties:
     instance_type: r5ad.24xlarge
-- name: g4dn.12xlarge
-  cloud_properties:
-    instance_type: g4dn.12xlarge
 - name: m5.24xlarge
   cloud_properties:
     instance_type: m5.24xlarge
@@ -268,9 +226,6 @@ vm_types:
 - name: x1e.2xlarge
   cloud_properties:
     instance_type: x1e.2xlarge
-- name: g4dn.metal
-  cloud_properties:
-    instance_type: g4dn.metal
 - name: c4.8xlarge
   cloud_properties:
     instance_type: c4.8xlarge
@@ -325,21 +280,12 @@ vm_types:
 - name: t2.nano
   cloud_properties:
     instance_type: t2.nano
-- name: i3.16xlarge
-  cloud_properties:
-    instance_type: i3.16xlarge
 - name: m5a.8xlarge
   cloud_properties:
     instance_type: m5a.8xlarge
 - name: r5.8xlarge
   cloud_properties:
     instance_type: r5.8xlarge
-- name: i2.4xlarge
-  cloud_properties:
-    instance_type: i2.4xlarge
-- name: g4dn.4xlarge
-  cloud_properties:
-    instance_type: g4dn.4xlarge
 - name: c5n.xlarge
   cloud_properties:
     instance_type: c5n.xlarge
@@ -364,12 +310,6 @@ vm_types:
 - name: c3.4xlarge
   cloud_properties:
     instance_type: c3.4xlarge
-- name: d2.xlarge
-  cloud_properties:
-    instance_type: d2.xlarge
-- name: p3dn.24xlarge
-  cloud_properties:
-    instance_type: p3dn.24xlarge
 - name: m5a.24xlarge
   cloud_properties:
     instance_type: m5a.24xlarge
@@ -391,15 +331,6 @@ vm_types:
 - name: r5d.8xlarge
   cloud_properties:
     instance_type: r5d.8xlarge
-- name: f1.4xlarge
-  cloud_properties:
-    instance_type: f1.4xlarge
-- name: g4dn.xlarge
-  cloud_properties:
-    instance_type: g4dn.xlarge
-- name: g4dn.8xlarge
-  cloud_properties:
-    instance_type: g4dn.8xlarge
 - name: c5.9xlarge
   cloud_properties:
     instance_type: c5.9xlarge
@@ -421,33 +352,18 @@ vm_types:
 - name: m5.4xlarge
   cloud_properties:
     instance_type: m5.4xlarge
-- name: f1.16xlarge
-  cloud_properties:
-    instance_type: f1.16xlarge
-- name: p3.8xlarge
-  cloud_properties:
-    instance_type: p3.8xlarge
 - name: c5n.metal
   cloud_properties:
     instance_type: c5n.metal
-- name: i3en.xlarge
-  cloud_properties:
-    instance_type: i3en.xlarge
 - name: r5d.metal
   cloud_properties:
     instance_type: r5d.metal
 - name: r5.xlarge
   cloud_properties:
     instance_type: r5.xlarge
-- name: i3.large
-  cloud_properties:
-    instance_type: i3.large
 - name: c5d.18xlarge
   cloud_properties:
     instance_type: c5d.18xlarge
-- name: i3.xlarge
-  cloud_properties:
-    instance_type: i3.xlarge
 - name: m3.2xlarge
   cloud_properties:
     instance_type: m3.2xlarge
@@ -475,18 +391,12 @@ vm_types:
 - name: m5a.large
   cloud_properties:
     instance_type: m5a.large
-- name: i3en.2xlarge
-  cloud_properties:
-    instance_type: i3en.2xlarge
 - name: x1e.xlarge
   cloud_properties:
     instance_type: x1e.xlarge
 - name: r4.4xlarge
   cloud_properties:
     instance_type: r4.4xlarge
-- name: g4dn.16xlarge
-  cloud_properties:
-    instance_type: g4dn.16xlarge
 - name: t2.xlarge
   cloud_properties:
     instance_type: t2.xlarge
@@ -496,15 +406,9 @@ vm_types:
 - name: m2.xlarge
   cloud_properties:
     instance_type: m2.xlarge
-- name: i3.2xlarge
-  cloud_properties:
-    instance_type: i3.2xlarge
 - name: c5.2xlarge
   cloud_properties:
     instance_type: c5.2xlarge
-- name: i3.metal
-  cloud_properties:
-    instance_type: i3.metal
 - name: r3.xlarge
   cloud_properties:
     instance_type: r3.xlarge
@@ -529,9 +433,6 @@ vm_types:
 - name: m4.2xlarge
   cloud_properties:
     instance_type: m4.2xlarge
-- name: i2.8xlarge
-  cloud_properties:
-    instance_type: i2.8xlarge
 - name: t3a.large
   cloud_properties:
     instance_type: t3a.large
@@ -544,30 +445,18 @@ vm_types:
 - name: m5.2xlarge
   cloud_properties:
     instance_type: m5.2xlarge
-- name: i3.4xlarge
-  cloud_properties:
-    instance_type: i3.4xlarge
 - name: c4.2xlarge
   cloud_properties:
     instance_type: c4.2xlarge
 - name: t2.medium
   cloud_properties:
     instance_type: t2.medium
-- name: p2.16xlarge
-  cloud_properties:
-    instance_type: p2.16xlarge
 - name: r5ad.2xlarge
   cloud_properties:
     instance_type: r5ad.2xlarge
 - name: r5ad.16xlarge
   cloud_properties:
     instance_type: r5ad.16xlarge
-- name: i3.8xlarge
-  cloud_properties:
-    instance_type: i3.8xlarge
-- name: d2.4xlarge
-  cloud_properties:
-    instance_type: d2.4xlarge
 - name: m4.10xlarge
   cloud_properties:
     instance_type: m4.10xlarge
@@ -577,12 +466,6 @@ vm_types:
 - name: r4.2xlarge
   cloud_properties:
     instance_type: r4.2xlarge
-- name: p2.xlarge
-  cloud_properties:
-    instance_type: p2.xlarge
-- name: p3.16xlarge
-  cloud_properties:
-    instance_type: p3.16xlarge
 - name: m5ad.16xlarge
   cloud_properties:
     instance_type: m5ad.16xlarge
@@ -592,9 +475,6 @@ vm_types:
 - name: x1e.16xlarge
   cloud_properties:
     instance_type: x1e.16xlarge
-- name: i3en.metal
-  cloud_properties:
-    instance_type: i3en.metal
 - name: m5d.24xlarge
   cloud_properties:
     instance_type: m5d.24xlarge
@@ -607,9 +487,6 @@ vm_types:
 - name: r5d.16xlarge
   cloud_properties:
     instance_type: r5d.16xlarge
-- name: i3en.large
-  cloud_properties:
-    instance_type: i3en.large
 - name: m5ad.24xlarge
   cloud_properties:
     instance_type: m5ad.24xlarge
@@ -622,12 +499,6 @@ vm_types:
 - name: c5.18xlarge
   cloud_properties:
     instance_type: c5.18xlarge
-- name: g4dn.2xlarge
-  cloud_properties:
-    instance_type: g4dn.2xlarge
-- name: i3en.6xlarge
-  cloud_properties:
-    instance_type: i3en.6xlarge
 - name: m1.medium
   cloud_properties:
     instance_type: m1.medium

--- a/generate-instance-config.sh
+++ b/generate-instance-config.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+i=$(aws ec2 describe-instance-types --region us-gov-west-1)
+nextToken=$(echo $i | jq -r '.NextToken')
+counter=0
+echo "$i" > temp-instance-$counter.json
+
+while [[ ${nextToken} != "null" && -n "${nextToken}" ]]; do
+    i=$(aws ec2 describe-instance-types --region us-gov-west-1 --next-token $nextToken)
+    nextToken=$(echo $i | jq -r '.NextToken')
+    counter=$((counter + 1))
+    echo "$i" > temp-instance-$counter.json
+done
+
+jq -r 'reduce inputs as $i (.; .InstanceTypes += $i.InstanceTypes)' temp-instance-*.json | \
+    jq -r '[.InstanceTypes[] | {"name":.InstanceType,"cloud_properties":{"instance_type":.InstanceType}}]' | \
+    yq read -
+
+rm temp-instance-*.json


### PR DESCRIPTION
## Changes proposed in this pull request:
- seeded the base cloud config with all us-gov-west-1 instance types.

This doesn't change any instance types, just makes the instance types AWS offers available under their type name to all bosh deployments, so it's both easier to understand deployed instance types and ensure that all instances are available without having to piecemeal configuration changes.

This is to help make the cost/resourcing changes easier to both understand and work with.

## security considerations

None, just an AWS configuration reference.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>