### PR TITLE
increased parallel worker count to 8.

### DIFF
--- a/operations/update.yml
+++ b/operations/update.yml
@@ -5,3 +5,8 @@
     canary_watch_time: 1000-600000
     update_watch_time: 1000-600000
     max_in_flight: 4
+
+# this doesn't exist in the default manifest but is part of the job spec.
+- type: replace
+  path: /instance_groups/name=bosh/jobs/name=director/properties?/director?/workers?
+  value: 8


### PR DESCRIPTION
## Changes proposed in this pull request:
- defaults to 3, updating to 8 so we can do more at once.

## security considerations

None.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>