### PR TITLE
Revert "Merge pull request #411 from 18F/all/worker-count"

### DIFF
--- a/operations/update.yml
+++ b/operations/update.yml
@@ -5,8 +5,3 @@
     canary_watch_time: 1000-600000
     update_watch_time: 1000-600000
     max_in_flight: 4
-
-# this doesn't exist in the default manifest but is part of the job spec.
-- type: replace
-  path: /instance_groups/name=bosh/jobs/name=director/properties?/director?/workers?
-  value: 8


### PR DESCRIPTION
## Changes proposed in this pull request:
- This reverts commit 832d5971df20c13be7c1ac4ba44f5f31e5e94d65, reversing
changes made to 3690a2c8c97a8596e4c2eecd55badeda6c466ec2.
- reverts #411 because apparently there are no default for some of the fields:
- broken build [#1252](https://ci.fr.cloud.gov/teams/main/pipelines/deploy-bosh/jobs/deploy-staging-bosh/builds/1252)

## security considerations

None.


