### PR TITLE
Adding Concourse az2

### DIFF
--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -51,7 +51,7 @@
         gateway: ((terraform_outputs.staging_concourse_subnet_gateway_az1))
         reserved:
           - ((terraform_outputs.staging_concourse_subnet_reserved_az1))
-        az: z1
+        az: z2
         dns: [((terraform_outputs.vpc_cidr_dns))]
         cloud_properties:
           subnet: ((terraform_outputs.staging_concourse_subnet_az1))
@@ -63,7 +63,7 @@
         gateway: ((terraform_outputs.staging_concourse_subnet_gateway_az2))
         reserved:
           - ((terraform_outputs.staging_concourse_subnet_reserved_az2))
-        az: z2
+        az: z1 # Yes, this looks backwards, it is not
         dns: [((terraform_outputs.vpc_cidr_dns))]
         cloud_properties:
           subnet: ((terraform_outputs.staging_concourse_subnet_az2))


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adding Concourse az2 to staging and production
- Staging didn't like being switched from z2 to z1 for existing vms so reversed to keep the current mapping so bosh's little brains don't implode again.
- Part of https://github.com/cloud-gov/terraform-provision/pull/1975

## security considerations
Just adds another az for vms, no change to security groups
