### PR TITLE
Remove reference to unused logsearch_elb

### DIFF
--- a/cloud-config/main.yml
+++ b/cloud-config/main.yml
@@ -158,13 +158,6 @@
 - type: replace
   path: /vm_extensions/-
   value:
-    name: logsearch-lb
-    cloud_properties:
-      elbs:
-      - ((terraform_outputs.logsearch_elb_name))
-- type: replace
-  path: /vm_extensions/-
-  value:
     name: platform-syslog-lb
     cloud_properties:
       elbs:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove reference to unused logsearch_elb
- Part of https://github.com/cloud-gov/private/issues/2584
-

## security considerations
Removes the extra unneeded vm extension
