### PR TITLE
Remove unused elasticache-broker-lb

### DIFF
--- a/cloud-config/main.yml
+++ b/cloud-config/main.yml
@@ -172,13 +172,6 @@
 - type: replace
   path: /vm_extensions/-
   value:
-    name: elasticache-broker-lb
-    cloud_properties:
-      elbs:
-      - ((terraform_outputs.elasticache_broker_elb_name))
-- type: replace
-  path: /vm_extensions/-
-  value:
     name: domains-broker-lb
     cloud_properties:
       lb_target_groups:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove unused elasticache-broker-lb
- Part of https://github.com/cloud-gov/private/issues/2584
-

## security considerations
Removes no longer needed vm extension
