### PR TITLE
Add distinct disk for prometheus-tooling vm

### DIFF
--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -578,5 +578,12 @@
       iops: 14_000
 
 - type: replace
+  path: /disk_types/-
+  value:
+    name: production-prometheus-tooling
+    disk_size: 120_000
+    cloud_properties:
+      type: gp3
+- type: replace
   path: /compilation/network?
   value: production-concourse


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add a new disk configuration to the cloud-config in tooling.
- End goal is to get instance_group `prometheus` and `prometheus-tooling` to no longer share disk configurations since they have very different storage space requirements, but doing this in steps since this configuration only exists on prometheus-production
- Part of https://github.com/cloud-gov/private/issues/2594

## security considerations
Adds a disk type, no security risks
