### PR TITLE
add new vm type for nessus manager

### DIFF
--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -397,6 +397,14 @@
 - type: replace
   path: /vm_types/-
   value:
+    name: m6i.xlarge.nessus.manager
+    cloud_properties:
+      instance_type: m6i.xlarge
+      ephemeral_disk:
+        size: 30_000
+- type: replace
+  path: /vm_types/-
+  value:
     <<: *concourse-iaas-worker-vm
     name: production-concourse-iaas-worker
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds the vm type m6i.xlarge for nessus manager

## security considerations
None, will be used to improve the performance of nessus manager by increasing cpu and memory