### PR TITLE
Remove rest of awslogs references

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -126,8 +126,6 @@ jobs:
       trigger: true
     - get: cg-s3-fisma-jammy-release
       trigger: true
-    - get: cg-s3-awslogs-jammy-release
-      trigger: true
     - get: cg-s3-nessus-agent-release
       trigger: true
     - get: cg-s3-clamav-release
@@ -161,7 +159,6 @@ jobs:
       inputs:
       - {name: certificate}
       - {name: cg-s3-fisma-jammy-release, path: releases/fisma-jammy}
-      - {name: cg-s3-awslogs-jammy-release, path: releases/awslogs-jammy}
       - {name: cg-s3-nessus-agent-release, path: releases/nessus-agent}
       - {name: cg-s3-clamav-release, path: releases/clamav}
       - {name: cg-s3-jammy-snort-release, path: releases/jammy-snort}
@@ -288,10 +285,6 @@ jobs:
     - get: terraform-yaml
       resource: terraform-yaml-production
     - get: cg-s3-fisma-jammy-release
-      trigger: true
-      passed:
-      - common-releases-master
-    - get: cg-s3-awslogs-jammy-release
       trigger: true
       passed:
       - common-releases-master
@@ -422,10 +415,6 @@ jobs:
       trigger: true
       passed:
       - common-releases-tooling
-    - get: cg-s3-awslogs-jammy-release
-      trigger: true
-      passed:
-      - common-releases-tooling
     - get: cg-s3-nessus-agent-release
       trigger: true
       passed:
@@ -549,10 +538,6 @@ jobs:
       trigger: true
       passed:
       - common-releases-development
-    - get: cg-s3-awslogs-jammy-release
-      trigger: true
-      passed:
-      - common-releases-development
     - get: cg-s3-nessus-agent-release
       trigger: true
       passed:
@@ -670,10 +655,6 @@ jobs:
     - get: terraform-yaml
       resource: terraform-yaml-production
     - get: cg-s3-fisma-jammy-release
-      trigger: true
-      passed:
-      - common-releases-staging
-    - get: cg-s3-awslogs-jammy-release
       trigger: true
       passed:
       - common-releases-staging
@@ -846,12 +827,6 @@ resources:
   type: s3-iam
   source:
     regexp: fisma-jammy-(.*).tgz
-    <<: *s3-release-params
-
-- name: cg-s3-awslogs-jammy-release
-  type: s3-iam
-  source:
-    regexp: awslogs-jammy-(.*).tgz
     <<: *s3-release-params
 
 - name: cg-s3-nessus-agent-release

--- a/ci/update-runtime-config.yml
+++ b/ci/update-runtime-config.yml
@@ -8,7 +8,6 @@ inputs:
   - { name: terraform-yaml }
   - { name: cg-s3-fisma-jammy-release, path: releases/fisma-jammy }
   - { name: aide-release, path: releases/aide }
-  - { name: cg-s3-awslogs-jammy-release, path: releases/awslogs-jammy }
   - { name: cg-s3-nessus-agent-release, path: releases/nessus-agent }
   - { name: cg-s3-clamav-release, path: releases/clamav }
   - { name: cg-s3-jammy-snort-release, path: releases/jammy-snort }

--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -10,9 +10,6 @@ releases:
 - name: nessus-agent
   uri: https://github.com/cloud-gov/cg-nessus-agent-boshrelease
   branch: main
-- name: awslogs-jammy
-  uri: https://github.com/cloud-gov/cg-awslogs-boshrelease
-  branch: jammy
 - name: clamav
   uri: https://github.com/cloud-gov/cg-clamav-boshrelease
   branch: main


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removes the awslogs release from being distributed to bosh directors
- Will manually updated pipeline after merge
- Part of https://github.com/cloud-gov/private/issues/2623

## security considerations
Part of retiring awslogs
