### PR TITLE
add profile to cloud config for logs opensearch

### DIFF
--- a/cloud-config/main.yml
+++ b/cloud-config/main.yml
@@ -198,6 +198,12 @@
 - type: replace
   path: /vm_extensions/-
   value:
+    name: logs-opensearch-profile
+    cloud_properties:
+      iam_instance_profile: ((terraform_outputs.logs_opensearch_profile))
+- type: replace
+  path: /vm_extensions/-
+  value:
     name: elasticache-broker-profile
     cloud_properties:
       iam_instance_profile: ((terraform_outputs.elasticache_broker_profile))


### PR DESCRIPTION
## Changes proposed in this pull request:

- add profile to cloud config for logs opensearch

## security considerations

The permissions for this new profile are tightly scoped to the least privileges necessary. See https://github.com/cloud-gov/terraform-provision/pull/2247
