### PR TITLE
bump platform data and force jammy for mamabosh

### DIFF
--- a/bosh-create-env.sh
+++ b/bosh-create-env.sh
@@ -14,6 +14,7 @@ bosh create-env \
   --ops-file bosh-deployment/aws/cpi.yml \
   --ops-file bosh-deployment/aws/iam-instance-profile.yml \
   --ops-file bosh-deployment/aws/cli-iam-instance-profile.yml \
+  --ops-file bosh-deployment/aws/use-jammy.yml \
   --ops-file bosh-deployment/uaa.yml \
   --ops-file bosh-deployment/credhub.yml \
   --ops-file bosh-deployment/jumpbox-user.yml \

--- a/cloud-config/main.yml
+++ b/cloud-config/main.yml
@@ -79,7 +79,7 @@
   path: /disk_types/-
   value:
     name: logsearch_es_platform_data
-    disk_size: 11_500_000
+    disk_size: 13_500_000
     cloud_properties:
       type: gp3
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:
- Logsearch Platform normal data nodes are slowly hitting their limit
- Ensure masterbosh uses latest jammy stemcell
-

## security considerations
None, routine maintenance 