### PR TITLE
Expand prometheus disk for v31 upgrade

### DIFF
--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -628,7 +628,7 @@
   value:
     <<: *prometheus-large-disk
     name: production-prometheus-large
-    disk_size: 1_200_000
+    disk_size: 2_000_000
 - type: replace
   path: /disk_types/-
   value:
@@ -646,7 +646,7 @@
   path: /disk_types/-
   value:
     name: production-prometheus-tooling
-    disk_size: 120_000
+    disk_size: 200_000
     cloud_properties:
       type: gp3
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:
- In order to upgrade to Prometheus v31, the persistent disk on `prometheus` and `prometheus-tooling` vms needs at least 50% free
- Only the production deployment is near the threshold so only those disks  are being expanded
- Part of https://github.com/cloud-gov/product/issues/2836

## security considerations
None.  Expands EBS volume sizes.
