### PR TITLE
Right-sizing prometheus disks post prometheus3 upgrade

### DIFF
--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -615,7 +615,7 @@
   path: /disk_types/-
   value: &prometheus-large-disk
     name: staging-prometheus-large
-    disk_size: 200_000
+    disk_size: 120_000
     cloud_properties:
       type: gp3
 - type: replace
@@ -628,25 +628,25 @@
   value:
     <<: *prometheus-large-disk
     name: production-prometheus-large
-    disk_size: 2_000_000
+    disk_size: 1_200_000
 - type: replace
   path: /disk_types/-
   value:
     <<: *prometheus-large-disk
     name: workshop-prometheus-large
-    disk_size: 400_000
+    disk_size: 50_000
 - type: replace
   path: /disk_types/-
   value:
     <<: *prometheus-large-disk
     name: pages-prometheus-large
-    disk_size: 400_000
+    disk_size: 50_000
 
 - type: replace
   path: /disk_types/-
   value:
     name: production-prometheus-tooling
-    disk_size: 200_000
+    disk_size: 120_000
     cloud_properties:
       type: gp3
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:
- After cleaning up `/var/vcap/store/prometheus2` folders on the prometheus deployments post the Prometheus3 upgrade in v31 of the release, we no longer need the extra storage space.
- Shrinking of disk size is not automatic on AWS.  A new disk is provisioned, the files copied and the old (larger) disk is unmounted and destroyed.  Should free up around $170/month of EC2 disk.
- Part of https://github.com/cloud-gov/private/issues/2810

## security considerations
None.  Changes disk sizes
