### PR TITLE
remove build of domain-broker BOSH release

### DIFF
--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -31,9 +31,6 @@ releases:
 - name: postfix
   uri: https://github.com/cloud-gov/postfix-boshrelease
   branch: main
-- name: domain-broker
-  uri: https://github.com/cloud-gov/cf-domain-broker-alb-boshrelease
-  branch: main
 - name: aide
   uri: https://github.com/cloud-gov/aide-boshrelease
   branch: main


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove build of domain-broker BOSH release, which is now fully deprecated and no longer in use

## security considerations

Removing unused software is good for maintenance and security
