### PR TITLE
fix permissions in security considerations workflow

### DIFF
--- a/.github/workflows/security-considerations.yml
+++ b/.github/workflows/security-considerations.yml
@@ -1,5 +1,8 @@
 name: Security Considerations
 
+permissions:
+  pull-requests: read
+
 on:
   pull_request:
     types: [opened, edited, reopened]


### PR DESCRIPTION
## Changes proposed in this pull request:

- Limit scope of permissions for security considerations workflow

## security considerations

This change limits the security considerations workflow to the minimum permissions necessary for it run, which is good for security
