### PR TITLE
Removing uaa-customized job in bosh-releases pipeline

### DIFF
--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -19,9 +19,6 @@ releases:
 - name: shibboleth
   uri: https://github.com/cloud-gov/shibboleth-boshrelease
   branch: main
-- name: uaa-customized
-  uri: https://github.com/cloud-gov/uaa-customized-boshrelease
-  branch: main
 - name: cron
   uri: https://github.com/cloud-gov/cron-boshrelease
   branch: main


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removing uaa-customized job in bosh-releases pipeline
- There is now a separate pipeline which builds and distributes the uaa-customized bosh release which replaces the uaa release
- Part of https://github.com/cloud-gov/private/issues/2875

## security considerations
No changes to security footprint, removes old pipeline that was creating the old uaa-customized bosh release
