### PR TITLE
expanding logsearch-platform dev disk

### DIFF
--- a/cloud-config/development.yml
+++ b/cloud-config/development.yml
@@ -12,4 +12,4 @@
   value: 400_000
 - type: replace
   path: /disk_types/name=logs_opensearch_os_platform_data/disk_size
-  value: 400_000
+  value: 600_000


### PR DESCRIPTION
## Changes proposed in this pull request:
- Increase disk for logsearch-platform in dev from 400 to 600 gb for growth

## security considerations
Gotta keep them logs
