### PR TITLE
add 15gb ephermeral to tooling cc

### DIFF
--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -584,7 +584,13 @@
     cloud_properties:
       ephemeral_disk:
         size: 10240
-
+- type: replace
+  path: /vm_extensions/-
+  value:
+    name: 15GB_ephemeral_disk
+    cloud_properties:
+      ephemeral_disk:
+        size: 15360
 - type: replace
   path: /disk_types/-
   value:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add tooling CC option for 15 GB ephemeral disk to account for larger non-persistent disk deployments and swap usage

## security considerations
n/a
