### PR TITLE
Remove platform-syslog-lb

### DIFF
--- a/cloud-config/main.yml
+++ b/cloud-config/main.yml
@@ -162,13 +162,6 @@
     cloud_properties:
       lb_target_groups:
       - ((terraform_outputs.shibboleth_lb_target_group))
-- type: replace
-  path: /vm_extensions/-
-  value:
-    name: platform-syslog-lb
-    cloud_properties:
-      elbs:
-      - ((terraform_outputs.platform_syslog_elb_name))
 
 - type: replace
   path: /vm_extensions/-


### PR DESCRIPTION
## Changes proposed in this pull request:
- Yoink deprecated `platform-syslog-lb`
- Part of logsearch-platform deprecation
-

## security considerations
Need to remove reference to load balancer which no longer exists, otherwise cloud-config cannot be updated
