### PR TITLE
Remove platform-kibana-lb

### DIFF
--- a/cloud-config/main.yml
+++ b/cloud-config/main.yml
@@ -166,14 +166,6 @@
 - type: replace
   path: /vm_extensions/-
   value:
-    name: platform-kibana-lb
-    cloud_properties:
-      lb_target_groups:
-      - ((terraform_outputs.platform_kibana_lb_target_group))
-      
-- type: replace
-  path: /vm_extensions/-
-  value:
     name: platform-opensearch-lb
     cloud_properties:
       lb_target_groups:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Yoink deprecated `platform-kibana-lb`
- Part of logsearch-platform deprecation
-

## security considerations
Need to remove reference to load balancer which no longer exists, otherwise cloud-config cannot be updated
