### PR TITLE
Remove cloud config for Logsearch

### DIFF
--- a/cloud-config/base.yml
+++ b/cloud-config/base.yml
@@ -104,11 +104,6 @@ vm_types:
     instance_type: r5.xlarge
     ephemeral_disk:
       size: 30000
-  name: r5.xlarge.logsearch.ingestor
-- cloud_properties:
-    instance_type: r5.xlarge
-    ephemeral_disk:
-      size: 30000
   name: r5.xlarge.logs_opensearch.ingestor
 - cloud_properties:
     instance_type: r6i.2xlarge
@@ -135,11 +130,6 @@ vm_types:
     ephemeral_disk:
       size: 15360
   name: r6i.xlarge
-- cloud_properties:
-    instance_type: r6i.xlarge
-    ephemeral_disk:
-      size: 30000
-  name: r6i.xlarge.logsearch.ingestor
 - cloud_properties:
     instance_type: t3.2xlarge
     ephemeral_disk:

--- a/cloud-config/development.yml
+++ b/cloud-config/development.yml
@@ -1,10 +1,4 @@
 - type: replace
-  path: /disk_types/name=logsearch_es_data/disk_size
-  value: 400_000
-- type: replace
-  path: /disk_types/name=logsearch_es_platform_data/disk_size
-  value: 400_000
-- type: replace
   path: /disk_types/name=logs_opensearch_os_data/disk_size
   value: 400_000
 - type: replace

--- a/cloud-config/main.yml
+++ b/cloud-config/main.yml
@@ -64,48 +64,6 @@
 - type: replace
   path: /disk_types/-
   value:
-    name: logsearch_es_master
-    disk_size: 102400
-    cloud_properties:
-      type: gp3
-- type: replace
-  path: /disk_types/-
-  value:
-    name: logsearch_es_data
-    disk_size: 16_500_000
-    cloud_properties:
-      type: gp3
-- type: replace
-  path: /disk_types/-
-  value:
-    name: logsearch_es_platform_data
-    disk_size: 13_500_000
-    cloud_properties:
-      type: gp3
-- type: replace
-  path: /disk_types/-
-  value:
-    name: logsearch_es_platform_data_warm
-    disk_size: 15_500_000
-    cloud_properties:
-      type: st1
-- type: replace
-  path: /disk_types/-
-  value:
-    name: logsearch_ingestor
-    disk_size: 64_000
-    cloud_properties:
-      type: gp3
-- type: replace
-  path: /disk_types/-
-  value:
-    name: logsearch_redis
-    disk_size: 4096
-    cloud_properties:
-      type: gp3
-- type: replace
-  path: /disk_types/-
-  value:
     name: logs_opensearch_os_master
     disk_size: 102400
     cloud_properties:
@@ -190,16 +148,10 @@
 - type: replace
   path: /vm_extensions/-
   value:
-    name: logsearch-ingestor-profile
-    cloud_properties:
-      iam_instance_profile: ((terraform_outputs.logsearch_ingestor_profile))
-- type: replace
-  path: /vm_extensions/-
-  value:
     name: platform-opensearch-ingestor-profile
     cloud_properties:
       iam_instance_profile: ((terraform_outputs.platform_opensearch_ingestor_profile))
-      
+
 - type: replace
   path: /vm_extensions/-
   value:

--- a/cloud-config/staging.yml
+++ b/cloud-config/staging.yml
@@ -1,7 +1,4 @@
 - type: replace
-  path: /disk_types/name=logsearch_es_data/disk_size
-  value: 900_000
-- type: replace
   path: /disk_types/name=logs_opensearch_os_data/disk_size
   value: 900_000
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove cloud config for Logsearch, including instance types, disk types, and instance profiles

## security considerations

None, the Logsearch deployment has been deleted
